### PR TITLE
Set controlRenderingCompatibilityVersion to 4.5 in web.config

### DIFF
--- a/PXWeb/Web.config
+++ b/PXWeb/Web.config
@@ -177,7 +177,7 @@
         -->
     <!--<customErrors mode="RemoteOnly" defaultRedirect="~/ErrorGeneral.aspx" />-->
     <customErrors mode="On" defaultRedirect="~/ErrorGeneral.aspx" />
-    <pages controlRenderingCompatibilityVersion="3.5" clientIDMode="AutoID">
+    <pages controlRenderingCompatibilityVersion="4.5" clientIDMode="AutoID">
       <controls>
         <add assembly="PCAxis.Web.Controls" namespace="PCAxis.Web.Controls.CommandBar" tagPrefix="pxc"/>
         <add assembly="PCAxis.Web.Controls" namespace="PCAxis.Web.Controls" tagPrefix="pxc"/>


### PR DESCRIPTION
Hi Guys

When testing on our pxweb instance I've realized that the language manager didn't work as expected anymore. The problem encountered is basically the one described in
https://stackoverflow.com/questions/52814225/asp-net-webform-multiline-textbox-adds-line-break-on-page-load-automatically/63403673#63403673

In order to fix it I had to increase the controlRenderingCompatibilityVersion to 4.5. As it might be useful to you guys as well, here's the PR.

I somehow didn't fully see the branching strategy, so I've chosen the master branch, maybe you need to adapt this.

Of course it's not a problem if you guys do not agree and reject the PR.

Cheers & thanks for your valuable work
Stef