### PR TITLE
Upgraded ControlRenderingCompatibilityVersion to 4.5 

### DIFF
--- a/PXWeb/Web.config
+++ b/PXWeb/Web.config
@@ -177,7 +177,7 @@
         -->
     <!--<customErrors mode="RemoteOnly" defaultRedirect="~/ErrorGeneral.aspx" />-->
     <customErrors mode="On" defaultRedirect="~/ErrorGeneral.aspx" />
-    <pages controlRenderingCompatibilityVersion="3.5" clientIDMode="AutoID">
+    <pages controlRenderingCompatibilityVersion="4.5" clientIDMode="AutoID">
       <controls>
         <add assembly="PCAxis.Web.Controls" namespace="PCAxis.Web.Controls.CommandBar" tagPrefix="pxc" />
         <add assembly="PCAxis.Web.Controls" namespace="PCAxis.Web.Controls" tagPrefix="pxc" />


### PR DESCRIPTION
Upgraded ControlRenderingCompatibilityVersion to 4.5 to fix bug in the language manager tool