### PR TITLE
Fix for issue #187 - Scroll the newly expanded branch into view

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+- Fix for issue #187, scroll expanded branch in treeview into view
 - Fixed bug when downloading files that added an extra byte, issue 167
 - Added a CHANGES.txt to the PxWeb reop
 - Added support for pivoted serializers i API, issues #154

--- a/PCAxis.Web.Controls/Menu/TableOfContent/TableOfContent.ascx
+++ b/PCAxis.Web.Controls/Menu/TableOfContent/TableOfContent.ascx
@@ -30,7 +30,7 @@
 <script>
 
     jQuery(document).ready(function () {
-        var offset = jQuery('.AspNet-TreeView-Collapse:first').offset();
+        var offset = jQuery('.AspNet-TreeView-Collapse.first').offset();
         if (offset) {
             jQuery('html, body').scrollTop(offset.top);
         }

--- a/PCAxis.Web.Controls/Menu/TableOfContent/TableOfContent.ascx
+++ b/PCAxis.Web.Controls/Menu/TableOfContent/TableOfContent.ascx
@@ -30,7 +30,7 @@
 <script>
 
     jQuery(document).ready(function () {
-        var offset = jQuery('.AspNet-TreeView-Collapse.first').offset();
+        var offset = jQuery('.AspNet-TreeView-Collapse.first()').offset();
         if (offset) {
             jQuery('html, body').scrollTop(offset.top);
         }


### PR DESCRIPTION
Deprecated jQuery syntax was used. Replaced it with the new syntax.