### PR TITLE
Fix for treeview scroll problem. Issue #187.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+- Fix for treeview scroll problem, resolves #187
 - new version of pcaxis.sql, resolves #190
 - Possible to localize mandatory footnote label, issue #185
 - Added admin setting to control variable sort order on selection page, issue #164 

--- a/PCAxis.Web.Controls/Menu/TableOfContent/TableOfContent.ascx
+++ b/PCAxis.Web.Controls/Menu/TableOfContent/TableOfContent.ascx
@@ -30,10 +30,6 @@
 <script>
 
     jQuery(document).ready(function () {
-        var offset = jQuery('.AspNet-TreeView-Collapse:first').offset();
-        if (offset) {
-            jQuery('html, body').scrollTop(offset.top);
-        }
         jQuery('a[rel="_blank"]').each(function () {
             jQuery(this).attr('target', '_blank');
         });

--- a/PXWeb/Menu.aspx.cs
+++ b/PXWeb/Menu.aspx.cs
@@ -165,6 +165,7 @@ namespace PXWeb
             if (!string.IsNullOrEmpty(url.Path))
             {
                 TableOfContent1.ExpandNode = url.Path;
+                Page.ClientScript.RegisterClientScriptBlock(this.GetType(), "ScrollToExpanded", "<script type='text/javascript'> jQuery(function() { var offset = jQuery('.AspNet-TreeView-Collapse').last().offset();if (offset) { jQuery('html, body').scrollTop(offset.top); } });</script>  ");
             }
         }
 


### PR DESCRIPTION
Moved scroll script from treeview component. Injects it when needed when returning from selection page.
Scrolls to the last expanded node instead of the first one.