### PR TITLE
Made the site logo clickable. Issue 197.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+- Made the site logo clickable, issue #197
 - Added admin setting to display external search link, issue #195 
 - Fix for treeview scroll problem, resolves #187
 - new version of pcaxis.sql, resolves #190

--- a/PXWeb/PxWeb.Master
+++ b/PXWeb/PxWeb.Master
@@ -39,8 +39,10 @@
             <header id="header" class="header flex-row flex-wrap justify-space-between">
                 <asp:HyperLink runat="server" ID="SkipToMain" CssClass="screenreader-only pxweb-link"></asp:HyperLink>
                 <div class="headerleft flex-row" role="banner">
+                    <asp:HyperLink runat="server" ID="LogoLink">
                         <img id="imgSiteLogo"  enableviewstate="false" runat="server" src="" alt="" class="imgSiteLogo" />
-                        <span class="siteLogoText"><asp:Literal ID="litAppName" EnableViewState="false" runat="server" /></span>
+                    </asp:HyperLink>
+                    <span class="siteLogoText"><asp:Literal ID="litAppName" EnableViewState="false" runat="server" /></span>
                 </div>
                 <div class="headerright">
                 <% if (PXWeb.Settings.Current.General.Site.ShowExternalSearchLink)

--- a/PXWeb/PxWeb.Master.cs
+++ b/PXWeb/PxWeb.Master.cs
@@ -131,6 +131,8 @@ namespace PXWeb
 
             if (!IsPostBack)
             {
+                InitializeLogoLink();
+
                 if (!DoNotUseBreadCrumb())
                 {
                     InitializeBreadcrumb();
@@ -433,7 +435,45 @@ namespace PXWeb
                 navigationFlowControl.Table = url.Table;
             }
         }
-         private void InitializeBreadcrumb()
+
+        private void InitializeLogoLink()
+        {
+            IPxUrl url = RouteInstance.PxUrlProvider.Create(null);
+
+            if (!string.IsNullOrEmpty(url.Database))
+            {
+                try
+                {
+                    IHomepageSettings homepage = PXWeb.Settings.Current.Database[url.Database].Homepages.GetHomepage(url.Language);
+
+                    if (string.IsNullOrWhiteSpace(homepage.Url))
+                    {
+                        return;
+                    }
+
+                    if (homepage.IsExternal)
+                    {
+                        LogoLink.NavigateUrl = homepage.Url;
+                    }
+                    else
+                    {
+                        LogoLink.NavigateUrl = LinkManager.CreateLink(homepage.Url);
+                    }
+                }
+                catch (Exception e)
+                {
+                    log.Debug("url.Database = " + url.Database + ", url.Language = " + url.Language);
+                    log.Error("The error.", e);
+                    throw e;
+                }
+            }
+            else
+            {
+                LogoLink.NavigateUrl = LinkManager.CreateLink("Default.aspx");
+            }
+        }
+
+        private void InitializeBreadcrumb()
          {
             IPxUrl url = RouteInstance.PxUrlProvider.Create(null);
             DatabaseInfo dbi = null;

--- a/PXWeb/PxWeb.Master.designer.cs
+++ b/PXWeb/PxWeb.Master.designer.cs
@@ -69,6 +69,15 @@ namespace PXWeb
         protected global::System.Web.UI.WebControls.HyperLink SkipToMain;
 
         /// <summary>
+        /// LogoLink control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.HyperLink LogoLink;
+
+        /// <summary>
         /// imgSiteLogo control.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Clicking the site logo will redirect you to the same URL as when clicking the home icon in the breadcrumb.