### PR TITLE
Adding html-lang-attribute to the texts for "Change language" links, …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+- Added lang-attribute to change-language-link (for screen-reader)
 - New version of Excel (1.0.2) which has better performance
 - Added a admin API endpoint for build/rebuild the Menu.xml file for PX file based databases
 - Made the site logo clickable, issue #197

--- a/PXWeb/PxWeb.Master.cs
+++ b/PXWeb/PxWeb.Master.cs
@@ -297,7 +297,7 @@ namespace PXWeb
             string langUrl = PCAxis.Web.Core.Management.LinkManager.CreateLink(Request.AppRelativeCurrentExecutionFilePath, false, linkItems.ToArray());
 
             string langText = PCAxis.Web.Core.Management.LocalizationManager.GetLocalizedString("PxWebChangeToThisLanguage", new CultureInfo(langName));
-            return String.Format("<div class=\"pxweb-link\"> <a class=\"px-change-lang\" href=\"{0}\"> <span class=\"link-text px-change-lang\">{1}</span></a> </div> ", langUrl, Server.HtmlEncode(langText));
+            return String.Format("<div class=\"pxweb-link\"> <a class=\"px-change-lang\" href=\"{0}\"> <span lang=\"{2}\" class=\"link-text px-change-lang\">{1}</span></a> </div> ", langUrl, Server.HtmlEncode(langText), langName);
         }
 
          /// <summary>


### PR DESCRIPTION
…e.g. on a swedish page the change-to-english-text: "English" is marked as  english.