### PR TITLE
Fixed error in downloading file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+- Removed the dynamic content that as faulty generated when downloading files
 - New admin setting to control display of code and text in the advanced serach result for variable values
 - Made the compact view the default view on the selection page.
 - Added lang-attribute to change-language-link (for screen-reader)

--- a/PCAxis.Web.Core/FileTypeMarkerControlBase.vb
+++ b/PCAxis.Web.Core/FileTypeMarkerControlBase.vb
@@ -123,7 +123,7 @@ Public Class FileTypeMarkerControlBase(Of TControl As FileTypeControlBase(Of TCo
         'r.End()
 
         r.Flush()
-        'r.SuppressContent = True
+        r.SuppressContent = True
         System.Web.HttpContext.Current.ApplicationInstance.CompleteRequest()
 
         'Page.Response.Clear()


### PR DESCRIPTION
When Downloading a file some clients might return Server sent to much data. This could be caused by the dynamic tags that are added in the master-pages
They can be disabled my setting the SupprestContent = true