### PR TITLE
Add the option of transparency in graph backgrounds

### DIFF
--- a/PCAxis.Charts/ChartHelper.cs
+++ b/PCAxis.Charts/ChartHelper.cs
@@ -147,6 +147,12 @@ namespace PCAxis.Chart
 
             Color backgroundColor = ColorTranslator.FromHtml(settings.BackgroundColor);
             chart.BackColor = Color.FromArgb(settings.BackgroundAlpha, backgroundColor);
+
+            if (settings.BackgroundAlpha != 255)
+            {
+                chart.AntiAliasing = AntiAliasingStyles.Graphics;
+            }
+
             return chart;
 
         }

--- a/PCAxis.Charts/ChartHelper.cs
+++ b/PCAxis.Charts/ChartHelper.cs
@@ -73,10 +73,10 @@ namespace PCAxis.Chart
                 // Guideline color
                 area.AxisY.MajorGrid.LineColor = System.Drawing.ColorTranslator.FromHtml(settings.GuidelinesColor);
                 area.AxisX.MajorGrid.LineColor = System.Drawing.ColorTranslator.FromHtml(settings.GuidelinesColor);
-
-                area.BackColor = System.Drawing.ColorTranslator.FromHtml(settings.BackgroundColorGraphs);
-                
+                Color color = System.Drawing.ColorTranslator.FromHtml(settings.BackgroundColorGraphs);
+                area.BackColor = Color.FromArgb(settings.ChartAlpha, color);     
             }
+
             //If line thickness is more than 0 draw a line around the chart
             if ( settings.LineThicknessPhrame > 0 )
             {
@@ -145,6 +145,8 @@ namespace PCAxis.Chart
             chart.Palette = ChartColorPalette.None;
             chart.PaletteCustomColors = lstColors.ToArray();
 
+            Color backgroundColor = ColorTranslator.FromHtml(settings.BackgroundColor);
+            chart.BackColor = Color.FromArgb(settings.BackgroundAlpha, backgroundColor);
             return chart;
 
         }

--- a/PCAxis.Charts/ChartSettings.cs
+++ b/PCAxis.Charts/ChartSettings.cs
@@ -55,6 +55,9 @@ namespace PCAxis.Chart
         public int LegendHeight { get; set; }
         public CultureInfo CurrentCulture { get; set; }
         public List<string> Colors { get; set; }
+        public int ChartAlpha { get; set; }
+        public int BackgroundAlpha { get; set; }
+        public string BackgroundColor { get; set; }
         public string Logotype { get; set; }
         public string FontName { get; set; }
         public bool ShowSource { get; set; }
@@ -95,7 +98,9 @@ namespace PCAxis.Chart
             LineColorPhrame = "#000000";
             Logotype = "";
             LogotypePath = "";
-            
+            BackgroundAlpha = 255;
+            ChartAlpha = 255;
+            BackgroundColor = "#ffffff";
 
         }
 

--- a/PXWeb/Admin/Features-Charts-General.aspx
+++ b/PXWeb/Admin/Features-Charts-General.aspx
@@ -14,18 +14,25 @@
             BindColorPicker('Guidelines', '#AAAAAA');
 
             BindColorPicker('AddColor', '#000000');
+
+            BindColorPicker('BackgroundColor', '#FFFFFF');
+
             $('.customWidget>div').css('z-index', '1000');
+
 
             $('.customWidgetSideControls>input:text').blur(function (event) {
                 var id = this.tabIndex;
                 switch (id) {
                     case 10000:
-                        id = "Guidelines";
+                        id = "BackgroundColor";
                         break;
                     case 10001:
-                        id = "BackgroundColorGraphs";
+                        id = "Guidelines";
                         break;
                     case 10002:
+                        id = "BackgroundColorGraphs";
+                        break;
+                    case 10003:
                         id = "LineColorPhrame";
                         break;
                     case 10005:
@@ -139,6 +146,33 @@
             ErrorMessage="*" ValidateEmptyText="True" CssClass="setting-field-validator" ></asp:CustomValidator>
         </div>
     </asp:Panel>
+
+        <div class="setting-field">
+        <asp:Label ID="lblBackgroundColor" runat="server" CssClass="settingFieldText" Text="<%$ PxString: PxWebAdminFeaturesChartsGeneralBackgroundColor %>"></asp:Label>         
+        <div class="settingFieldControls">
+            <div id="customWidgetBackgroundColor" class="customWidget">
+                <div id="selectorBackgroundColor" class="colorpickerselector">
+                    <div style="background-color: <%# BackgroundColor %>"></div>
+                </div>
+                <div id="pickerBackgroundColor" class="colorpickercontainer"></div>
+            </div>
+            <div id="deleteButtonBackgroundColor" class="customWidgetSideControls">
+                <asp:TextBox runat="server" TabIndex="10000" MaxLength="7"  ID="txtBackgroundColor" CssClass="selectedColorBackgroundColor colorTextField" />
+                <asp:ImageButton ID="imgBackgroundColor" runat="server" onclick="BackgroundColorInfo" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />
+            </div>    
+        </div>
+         <asp:CustomValidator ID="validatorBackgroundColor" runat="server" 
+        ControlToValidate="txtBackgroundColor" OnServerValidate="ValidateColor"
+        ErrorMessage="*" ValidateEmptyText="True" CssClass="setting-field-validator" ></asp:CustomValidator>
+
+        <asp:Label ID="lblBackgroundAlpha" runat="server" Text="<%$ PxString: PxWebAdminFeaturesChartsGeneralBackgroundAlpha %>"></asp:Label>
+        <asp:TextBox ID="txtBackgroundAlpha" runat="server" CssClass="mediuminput" MaxLength="3"></asp:TextBox>
+        <asp:ImageButton ID="imgBackgroundAlpha" runat="server" onclick="BackgroundAlphaInfo" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />
+         <asp:CustomValidator ID="BackgroundAlphaValidator" runat="server" 
+        ControlToValidate="txtBackgroundAlpha" OnServerValidate="ValidateAlpha"
+        ErrorMessage="*" ValidateEmptyText="True" CssClass="setting-field-validator" ></asp:CustomValidator>
+    </div>
+
     <div class="setting-field">
         <asp:Label ID="lblGuidelinesColor" runat="server" CssClass="settingFieldText" Text="<%$ PxString: PxWebAdminFeaturesChartsGeneralGuidelinesColor %>"></asp:Label>         
         <div class="settingFieldControls">
@@ -149,7 +183,7 @@
                 <div id="pickerGuidelines" class="colorpickercontainer"></div>
             </div>
             <div id="deleteButtonGuidelines" class="customWidgetSideControls">
-                <asp:TextBox runat="server" TabIndex="10000" MaxLength="7"  ID="txtGuidelinesColor" CssClass="selectedColorGuidelines colorTextField" />
+                <asp:TextBox runat="server" TabIndex="10001" MaxLength="7"  ID="txtGuidelinesColor" CssClass="selectedColorGuidelines colorTextField" />
                 <asp:ImageButton ID="imgGuidelinesColor" runat="server" onclick="GuidelinesColorInfo" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />
             </div>    
         </div>
@@ -167,12 +201,19 @@
                 <div id="pickerBackgroundColorGraphs" class="colorpickercontainer"></div>
             </div>
             <div id="deleteButtonBackgroundColorGraphs" class="customWidgetSideControls">
-                <asp:TextBox runat="server" TabIndex="10001" MaxLength="7"  ID="txtBackgroundColorGraphs" CssClass="selectedColorBackgroundColorGraphs colorTextField" />
+                <asp:TextBox runat="server" TabIndex="10002" MaxLength="7"  ID="txtBackgroundColorGraphs" CssClass="selectedColorBackgroundColorGraphs colorTextField" />
                 <asp:ImageButton ID="imgBackgroundColorGraphs" runat="server" onclick="BackgroundColorGraphsInfo" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />
             </div>    
         </div>
          <asp:CustomValidator ID="CustomValidator3" runat="server" 
         ControlToValidate="txtBackgroundColorGraphs" OnServerValidate="ValidateColor"
+        ErrorMessage="*" ValidateEmptyText="True" CssClass="setting-field-validator" ></asp:CustomValidator>
+
+        <asp:Label ID="lblChartAlpha" runat="server" Text="<%$ PxString: PxWebAdminFeaturesChartsGeneralChartAlpha %>"></asp:Label>
+        <asp:TextBox ID="txtChartAlpha" runat="server" CssClass="mediuminput" MaxLength="3"></asp:TextBox>
+        <asp:ImageButton ID="imgChartAlpha" runat="server" onclick="ChartAlphaInfo" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />
+         <asp:CustomValidator ID="validatorChartAlpha" runat="server" 
+        ControlToValidate="txtChartAlpha" OnServerValidate="ValidateAlpha"
         ErrorMessage="*" ValidateEmptyText="True" CssClass="setting-field-validator" ></asp:CustomValidator>
     </div>
     <div class="setting-field">
@@ -185,7 +226,7 @@
                 <div id="pickerLineColorPhrame" class="colorpickercontainer"></div>
             </div>
             <div id="deleteLineColorPhrame" class="customWidgetSideControls">
-                <asp:TextBox runat="server" TabIndex="10002" MaxLength="7"  ID="txtLineColorPhrame" CssClass="selectedColorLineColorPhrame colorTextField" />
+                <asp:TextBox runat="server" TabIndex="10003" MaxLength="7"  ID="txtLineColorPhrame" CssClass="selectedColorLineColorPhrame colorTextField" />
                 <asp:ImageButton ID="imgLineColorPhrame" runat="server" onclick="LineColorPhrameInfo" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />
             </div>    
         </div>
@@ -195,7 +236,7 @@
     </div>
     <div class="setting-field">
         <asp:Label ID="lblLineThicknessPhrame" runat="server" Text="<%$ PxString: PxWebAdminFeaturesChartsGeneralLineThicknessPhrame %>"></asp:Label>
-        <asp:TextBox ID="txtLineThicknessPhrame" runat="server" CssClass="smallinput" MaxLength="10" TabIndex="10003"></asp:TextBox>
+        <asp:TextBox ID="txtLineThicknessPhrame" runat="server" CssClass="smallinput" MaxLength="10" TabIndex="10004"></asp:TextBox>
         <asp:ImageButton ID="imgLineThicknessPhrame" runat="server" onclick="LineThicknessPhrameInfo" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />
          <asp:CustomValidator ID="CustomValidatorPhrame" runat="server" 
         ControlToValidate="txtLineThicknessPhrame" OnServerValidate="ValidateLineThicknessPhrame"

--- a/PXWeb/Admin/Features-Charts-General.aspx.cs
+++ b/PXWeb/Admin/Features-Charts-General.aspx.cs
@@ -43,6 +43,15 @@ namespace PXWeb.Admin
             }
         }
 
+        private string _backgroundColor = "#FFFFFF";
+        public string BackgroundColor
+        {
+            get
+            {
+                return _backgroundColor;
+            }
+        }
+
         protected void Page_Load(object sender, EventArgs e)
         {
             // Very ugly fix for weird javascript error that only occur in IE11.
@@ -119,6 +128,10 @@ namespace PXWeb.Admin
             txtLineColorPhrame.Text = PXWeb.Settings.Current.Features.Charts.LineColorPhrame.ToString();
             _backgroundColorGraphs = PXWeb.Settings.Current.Features.Charts.BackgroundColorGraphs.ToString();
             txtBackgroundColorGraphs.Text = PXWeb.Settings.Current.Features.Charts.BackgroundColorGraphs.ToString();
+            _backgroundColor = PXWeb.Settings.Current.Features.Charts.BackgroundColor.ToString();
+            txtBackgroundColor.Text = PXWeb.Settings.Current.Features.Charts.BackgroundColor.ToString();
+            txtChartAlpha.Text = PXWeb.Settings.Current.Features.Charts.ChartAlpha.ToString();
+            txtBackgroundAlpha.Text = PXWeb.Settings.Current.Features.Charts.BackgroundAlpha.ToString();
 
             rptColors.DataSource = PXWeb.Settings.Current.Features.Charts.Colors;
             rptColors.DataBind();
@@ -176,6 +189,10 @@ namespace PXWeb.Admin
                         _lineColorPhrame = txtLineColorPhrame.Text;
                         charts.BackgroundColorGraphs = txtBackgroundColorGraphs.Text;
                         _backgroundColorGraphs = txtBackgroundColorGraphs.Text;
+                        charts.BackgroundColor = txtBackgroundColor.Text;
+                        _backgroundColor = txtBackgroundColor.Text;
+                        charts.BackgroundAlpha = int.Parse(txtBackgroundAlpha.Text);
+                        charts.ChartAlpha = int.Parse(txtChartAlpha.Text);
 
                         SetColors(rptColors, (List<string>)charts.Colors);
 
@@ -396,6 +413,38 @@ namespace PXWeb.Admin
             if (int.Parse(args.Value) > 100)
             {
                 SetValidationError(val, args, "PxWebAdminSettingsValidationMaximumValue", "100");
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Validates alpha value (0, 255)
+        /// </summary>
+        /// <param name="source">Validator object</param>
+        /// <param name="args">Validation arguments</param>
+        public void ValidateAlpha(object source, System.Web.UI.WebControls.ServerValidateEventArgs args)
+        {
+            CustomValidator val = (CustomValidator)source;
+            int alpha;
+            try
+            {
+                alpha = int.Parse(args.Value);
+            }
+            catch (System.FormatException e)
+            {
+                SetValidationError(val, args, "Invalid number");
+                return;
+            }
+
+            if (alpha > 255)
+            {
+                SetValidationError(val, args, "Alpha must not be higher than 255");
+                return;
+            }
+
+            if (alpha < 0)
+            {
+                SetValidationError(val, args, "Alpha must not be lower than 0");
                 return;
             }
         }
@@ -660,6 +709,11 @@ namespace PXWeb.Admin
         {
             Master.ShowInfoDialog("PxWebAdminFeaturesChartsGeneralGuidelinesColor", "PxWebAdminFeaturesChartsGeneralGuidelinesColorInfo");
         }
+
+        protected void BackgroundColorInfo(object sender, ImageClickEventArgs e)
+        {
+            Master.ShowInfoDialog("PxWebAdminFeaturesChartsGeneralBackgroundColor", "PxWebAdminFeaturesChartsGeneralBackgroundColorInfo");
+        }
         protected void GuidelinesHorizontalInfo(object sender, ImageClickEventArgs e)
         {
             Master.ShowInfoDialog("PxWebAdminFeaturesChartsGeneralGuidelinesHorizontal", "PxWebAdminFeaturesChartsGeneralGuidelinesHorizontalInfo");
@@ -695,6 +749,14 @@ namespace PXWeb.Admin
         protected void BackgroundColorGraphsInfo(object sender, ImageClickEventArgs e)
         {
             Master.ShowInfoDialog("PxWebAdminFeaturesChartsGeneralBackgroundColorGraphs", "PxWebAdminFeaturesChartsGeneralBackgroundColorGraphsInfo");
+        }
+        protected void ChartAlphaInfo(object sender, ImageClickEventArgs e)
+        {
+            Master.ShowInfoDialog("PxWebAdminFeaturesChartsGeneralAlpha", "PxWebAdminFeaturesChartsGeneralChartAlphaInfo");
+        }
+        protected void BackgroundAlphaInfo(object sender, ImageClickEventArgs e)
+        {
+            Master.ShowInfoDialog("PxWebAdminFeaturesChartsGeneralAlpha", "PxWebAdminFeaturesChartsGeneralBackgroundAlphaInfo");
         }
         protected void LineColorPhrameInfo(object sender, ImageClickEventArgs e)
         {

--- a/PXWeb/Admin/Features-Charts-General.aspx.designer.cs
+++ b/PXWeb/Admin/Features-Charts-General.aspx.designer.cs
@@ -7,11 +7,13 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PXWeb.Admin {
-    
-    
-    public partial class Features_Charts_General {
-        
+namespace PXWeb.Admin
+{
+
+
+    public partial class Features_Charts_General
+    {
+
         /// <summary>
         /// lblChartSetting control.
         /// </summary>
@@ -20,7 +22,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblChartSetting;
-        
+
         /// <summary>
         /// lblFontName control.
         /// </summary>
@@ -29,7 +31,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblFontName;
-        
+
         /// <summary>
         /// cboFontName control.
         /// </summary>
@@ -38,7 +40,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboFontName;
-        
+
         /// <summary>
         /// imgFontName control.
         /// </summary>
@@ -47,7 +49,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgFontName;
-        
+
         /// <summary>
         /// lblFontSizeTitle control.
         /// </summary>
@@ -56,7 +58,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblFontSizeTitle;
-        
+
         /// <summary>
         /// txtFontSizeTitle control.
         /// </summary>
@@ -65,7 +67,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtFontSizeTitle;
-        
+
         /// <summary>
         /// imgFontSizeTitle control.
         /// </summary>
@@ -74,7 +76,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgFontSizeTitle;
-        
+
         /// <summary>
         /// validatorFontSizeTitle control.
         /// </summary>
@@ -83,7 +85,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorFontSizeTitle;
-        
+
         /// <summary>
         /// lblFontSizeAxis control.
         /// </summary>
@@ -92,7 +94,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblFontSizeAxis;
-        
+
         /// <summary>
         /// txtFontSizeAxis control.
         /// </summary>
@@ -101,7 +103,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtFontSizeAxis;
-        
+
         /// <summary>
         /// imgFontSizeAxis control.
         /// </summary>
@@ -110,7 +112,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgFontSizeAxis;
-        
+
         /// <summary>
         /// validatorFontSizeAxis control.
         /// </summary>
@@ -119,7 +121,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorFontSizeAxis;
-        
+
         /// <summary>
         /// lblLegendFontSize control.
         /// </summary>
@@ -128,7 +130,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblLegendFontSize;
-        
+
         /// <summary>
         /// txtLegendFontSize control.
         /// </summary>
@@ -137,7 +139,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtLegendFontSize;
-        
+
         /// <summary>
         /// imgLegendFontSize control.
         /// </summary>
@@ -146,7 +148,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgLegendFontSize;
-        
+
         /// <summary>
         /// validatorLegendFontSize control.
         /// </summary>
@@ -155,7 +157,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorLegendFontSize;
-        
+
         /// <summary>
         /// lblMaxHeight control.
         /// </summary>
@@ -164,7 +166,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblMaxHeight;
-        
+
         /// <summary>
         /// txtMaxHeight control.
         /// </summary>
@@ -173,7 +175,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtMaxHeight;
-        
+
         /// <summary>
         /// imgMaxHeight control.
         /// </summary>
@@ -182,7 +184,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgMaxHeight;
-        
+
         /// <summary>
         /// validatorMaxHeight control.
         /// </summary>
@@ -191,7 +193,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorMaxHeight;
-        
+
         /// <summary>
         /// lblMaxWidth control.
         /// </summary>
@@ -200,7 +202,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblMaxWidth;
-        
+
         /// <summary>
         /// txtMaxWidth control.
         /// </summary>
@@ -209,7 +211,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtMaxWidth;
-        
+
         /// <summary>
         /// imgMaxWidth control.
         /// </summary>
@@ -218,7 +220,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgMaxWidth;
-        
+
         /// <summary>
         /// CustomValidator1 control.
         /// </summary>
@@ -227,7 +229,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator CustomValidator1;
-        
+
         /// <summary>
         /// lblMaxLineThickness control.
         /// </summary>
@@ -236,7 +238,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblMaxLineThickness;
-        
+
         /// <summary>
         /// txtMaxLineThickness control.
         /// </summary>
@@ -245,7 +247,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtMaxLineThickness;
-        
+
         /// <summary>
         /// imgMaxLineThickness control.
         /// </summary>
@@ -254,7 +256,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgMaxLineThickness;
-        
+
         /// <summary>
         /// validatorMaxLineThickness control.
         /// </summary>
@@ -263,7 +265,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorMaxLineThickness;
-        
+
         /// <summary>
         /// lblMaxValues control.
         /// </summary>
@@ -272,7 +274,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblMaxValues;
-        
+
         /// <summary>
         /// txtMaxValues control.
         /// </summary>
@@ -281,7 +283,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtMaxValues;
-        
+
         /// <summary>
         /// imgMaxValues control.
         /// </summary>
@@ -290,7 +292,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgMaxValues;
-        
+
         /// <summary>
         /// validatorMaxValues control.
         /// </summary>
@@ -299,7 +301,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorMaxValues;
-        
+
         /// <summary>
         /// lblShowSourse control.
         /// </summary>
@@ -308,7 +310,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblShowSourse;
-        
+
         /// <summary>
         /// cboShowSourse control.
         /// </summary>
@@ -317,7 +319,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboShowSourse;
-        
+
         /// <summary>
         /// imgShowSourse control.
         /// </summary>
@@ -326,7 +328,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgShowSourse;
-        
+
         /// <summary>
         /// lblShowLogo control.
         /// </summary>
@@ -335,7 +337,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblShowLogo;
-        
+
         /// <summary>
         /// cboShowLogo control.
         /// </summary>
@@ -344,7 +346,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboShowLogo;
-        
+
         /// <summary>
         /// imgShowLogo control.
         /// </summary>
@@ -353,7 +355,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgShowLogo;
-        
+
         /// <summary>
         /// pnlLogotypeInGraphs control.
         /// </summary>
@@ -362,7 +364,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Panel pnlLogotypeInGraphs;
-        
+
         /// <summary>
         /// lblImgLogo control.
         /// </summary>
@@ -371,7 +373,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblImgLogo;
-        
+
         /// <summary>
         /// txtPathImgLogo control.
         /// </summary>
@@ -380,7 +382,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtPathImgLogo;
-        
+
         /// <summary>
         /// imgImgLogo control.
         /// </summary>
@@ -389,7 +391,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgImgLogo;
-        
+
         /// <summary>
         /// CustomValidator2 control.
         /// </summary>
@@ -398,7 +400,79 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator CustomValidator2;
-        
+
+        /// <summary>
+        /// lblBackgroundColor control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblBackgroundColor;
+
+        /// <summary>
+        /// txtBackgroundColor control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtBackgroundColor;
+
+        /// <summary>
+        /// imgBackgroundColor control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.ImageButton imgBackgroundColor;
+
+        /// <summary>
+        /// validatorBackgroundColor control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CustomValidator validatorBackgroundColor;
+
+        /// <summary>
+        /// lblBackgroundAlpha control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblBackgroundAlpha;
+
+        /// <summary>
+        /// txtBackgroundAlpha control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtBackgroundAlpha;
+
+        /// <summary>
+        /// imgBackgroundAlpha control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.ImageButton imgBackgroundAlpha;
+
+        /// <summary>
+        /// BackgroundAlphaValidator control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CustomValidator BackgroundAlphaValidator;
+
         /// <summary>
         /// lblGuidelinesColor control.
         /// </summary>
@@ -407,7 +481,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblGuidelinesColor;
-        
+
         /// <summary>
         /// txtGuidelinesColor control.
         /// </summary>
@@ -416,7 +490,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtGuidelinesColor;
-        
+
         /// <summary>
         /// imgGuidelinesColor control.
         /// </summary>
@@ -425,7 +499,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgGuidelinesColor;
-        
+
         /// <summary>
         /// validatorGuidelinesColor control.
         /// </summary>
@@ -434,7 +508,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorGuidelinesColor;
-        
+
         /// <summary>
         /// lblBackgroundColorGraphs control.
         /// </summary>
@@ -443,7 +517,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblBackgroundColorGraphs;
-        
+
         /// <summary>
         /// txtBackgroundColorGraphs control.
         /// </summary>
@@ -452,7 +526,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtBackgroundColorGraphs;
-        
+
         /// <summary>
         /// imgBackgroundColorGraphs control.
         /// </summary>
@@ -461,7 +535,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgBackgroundColorGraphs;
-        
+
         /// <summary>
         /// CustomValidator3 control.
         /// </summary>
@@ -470,7 +544,43 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator CustomValidator3;
-        
+
+        /// <summary>
+        /// lblChartAlpha control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblChartAlpha;
+
+        /// <summary>
+        /// txtChartAlpha control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtChartAlpha;
+
+        /// <summary>
+        /// imgChartAlpha control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.ImageButton imgChartAlpha;
+
+        /// <summary>
+        /// validatorChartAlpha control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CustomValidator validatorChartAlpha;
+
         /// <summary>
         /// lblLineColorPhrame control.
         /// </summary>
@@ -479,7 +589,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblLineColorPhrame;
-        
+
         /// <summary>
         /// txtLineColorPhrame control.
         /// </summary>
@@ -488,7 +598,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtLineColorPhrame;
-        
+
         /// <summary>
         /// imgLineColorPhrame control.
         /// </summary>
@@ -497,7 +607,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgLineColorPhrame;
-        
+
         /// <summary>
         /// CustomValidator4 control.
         /// </summary>
@@ -506,7 +616,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator CustomValidator4;
-        
+
         /// <summary>
         /// lblLineThicknessPhrame control.
         /// </summary>
@@ -515,7 +625,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblLineThicknessPhrame;
-        
+
         /// <summary>
         /// txtLineThicknessPhrame control.
         /// </summary>
@@ -524,7 +634,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtLineThicknessPhrame;
-        
+
         /// <summary>
         /// imgLineThicknessPhrame control.
         /// </summary>
@@ -533,7 +643,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgLineThicknessPhrame;
-        
+
         /// <summary>
         /// CustomValidatorPhrame control.
         /// </summary>
@@ -542,7 +652,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator CustomValidatorPhrame;
-        
+
         /// <summary>
         /// lblColors control.
         /// </summary>
@@ -551,7 +661,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblColors;
-        
+
         /// <summary>
         /// imgColors control.
         /// </summary>
@@ -560,7 +670,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgColors;
-        
+
         /// <summary>
         /// rptColors control.
         /// </summary>
@@ -569,7 +679,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Repeater rptColors;
-        
+
         /// <summary>
         /// txtAddSelectedColor control.
         /// </summary>
@@ -578,7 +688,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtAddSelectedColor;
-        
+
         /// <summary>
         /// lnkAddColor control.
         /// </summary>
@@ -587,7 +697,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton lnkAddColor;
-        
+
         /// <summary>
         /// validatorAddColor control.
         /// </summary>
@@ -596,7 +706,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorAddColor;
-        
+
         /// <summary>
         /// Label1 control.
         /// </summary>
@@ -605,7 +715,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label Label1;
-        
+
         /// <summary>
         /// lblHeight control.
         /// </summary>
@@ -614,7 +724,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblHeight;
-        
+
         /// <summary>
         /// txtHeight control.
         /// </summary>
@@ -623,7 +733,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtHeight;
-        
+
         /// <summary>
         /// imgHeight control.
         /// </summary>
@@ -632,7 +742,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgHeight;
-        
+
         /// <summary>
         /// validatorHeight control.
         /// </summary>
@@ -641,7 +751,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorHeight;
-        
+
         /// <summary>
         /// lblWidth control.
         /// </summary>
@@ -650,7 +760,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblWidth;
-        
+
         /// <summary>
         /// txtWidth control.
         /// </summary>
@@ -659,7 +769,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtWidth;
-        
+
         /// <summary>
         /// imgWidth control.
         /// </summary>
@@ -668,7 +778,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgWidth;
-        
+
         /// <summary>
         /// validatorWidth control.
         /// </summary>
@@ -677,7 +787,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorWidth;
-        
+
         /// <summary>
         /// lblLineThickness control.
         /// </summary>
@@ -686,7 +796,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblLineThickness;
-        
+
         /// <summary>
         /// txtLineThickness control.
         /// </summary>
@@ -695,7 +805,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtLineThickness;
-        
+
         /// <summary>
         /// imgLineThickness control.
         /// </summary>
@@ -704,7 +814,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgLineThickness;
-        
+
         /// <summary>
         /// validatorLineThickness control.
         /// </summary>
@@ -713,7 +823,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorLineThickness;
-        
+
         /// <summary>
         /// lblLabelOrientation control.
         /// </summary>
@@ -722,7 +832,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblLabelOrientation;
-        
+
         /// <summary>
         /// cboLabelOrientation control.
         /// </summary>
@@ -731,7 +841,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboLabelOrientation;
-        
+
         /// <summary>
         /// imgLabelOrientation control.
         /// </summary>
@@ -740,7 +850,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgLabelOrientation;
-        
+
         /// <summary>
         /// lblTimeSortOrder control.
         /// </summary>
@@ -749,7 +859,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblTimeSortOrder;
-        
+
         /// <summary>
         /// cboTimeSortOrder control.
         /// </summary>
@@ -758,7 +868,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboTimeSortOrder;
-        
+
         /// <summary>
         /// imgTimeSortOrder control.
         /// </summary>
@@ -767,7 +877,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgTimeSortOrder;
-        
+
         /// <summary>
         /// lblShowLegend control.
         /// </summary>
@@ -776,7 +886,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblShowLegend;
-        
+
         /// <summary>
         /// cboShowLegend control.
         /// </summary>
@@ -785,7 +895,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboShowLegend;
-        
+
         /// <summary>
         /// imgShowLegend control.
         /// </summary>
@@ -794,7 +904,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgShowLegend;
-        
+
         /// <summary>
         /// lblLegendHeight control.
         /// </summary>
@@ -803,7 +913,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblLegendHeight;
-        
+
         /// <summary>
         /// txtLegendHeight control.
         /// </summary>
@@ -812,7 +922,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtLegendHeight;
-        
+
         /// <summary>
         /// imgLegendHeight control.
         /// </summary>
@@ -821,7 +931,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgLegendHeight;
-        
+
         /// <summary>
         /// validatorLegendHeight control.
         /// </summary>
@@ -830,7 +940,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorLegendHeight;
-        
+
         /// <summary>
         /// lblGuidelinesHorizontal control.
         /// </summary>
@@ -839,7 +949,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblGuidelinesHorizontal;
-        
+
         /// <summary>
         /// cboGuidelinesHorizontal control.
         /// </summary>
@@ -848,7 +958,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboGuidelinesHorizontal;
-        
+
         /// <summary>
         /// imgGuidelinesHorizontal control.
         /// </summary>
@@ -857,7 +967,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgGuidelinesHorizontal;
-        
+
         /// <summary>
         /// lblGuidelinesVertical control.
         /// </summary>
@@ -866,7 +976,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblGuidelinesVertical;
-        
+
         /// <summary>
         /// cboGuidelinesVertical control.
         /// </summary>
@@ -875,7 +985,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboGuidelinesVertical;
-        
+
         /// <summary>
         /// imgGuidelinesVertical control.
         /// </summary>
@@ -884,15 +994,17 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgGuidelinesVertical;
-        
+
         /// <summary>
         /// Master property.
         /// </summary>
         /// <remarks>
         /// Auto-generated property.
         /// </remarks>
-        public new PXWeb.Admin.Admin Master {
-            get {
+        public new PXWeb.Admin.Admin Master
+        {
+            get
+            {
                 return ((PXWeb.Admin.Admin)(base.Master));
             }
         }

--- a/PXWeb/Code/Settings/ChartsSettings.cs
+++ b/PXWeb/Code/Settings/ChartsSettings.cs
@@ -117,6 +117,15 @@ namespace PXWeb
             xpath = "./backgroundColorGraphs";
             BackgroundColorGraphs = SettingsHelper.GetSettingValue(xpath, chartsNode, "#FFFFFF");
 
+            xpath = "./backgroundAlpha";
+            BackgroundAlpha = SettingsHelper.GetSettingValue(xpath, chartsNode, 255);
+
+            xpath = "./chartAlpha";
+            ChartAlpha = SettingsHelper.GetSettingValue(xpath, chartsNode, 255);
+
+            xpath = "./backgroundColor";
+            BackgroundColor = SettingsHelper.GetSettingValue(xpath, chartsNode, "#FFFFFF");
+
         }
 
         /// <summary>
@@ -188,6 +197,15 @@ namespace PXWeb
             xpath = "./backgroundColorGraphs";
             SettingsHelper.SetSettingValue(xpath, chartsNode, BackgroundColorGraphs.ToString());
 
+            xpath = "./backgroundAlpha";
+            SettingsHelper.SetSettingValue(xpath, chartsNode, BackgroundAlpha.ToString());
+
+            xpath = "./chartAlpha";
+            SettingsHelper.SetSettingValue(xpath, chartsNode, ChartAlpha.ToString());
+
+            xpath = "./backgroundColor";
+            SettingsHelper.SetSettingValue(xpath, chartsNode, BackgroundColor.ToString());
+
         }
 
         #endregion
@@ -211,6 +229,9 @@ namespace PXWeb
         public string BackgroundColorGraphs { get; set; }
         public int LineThicknessPhrame { get; set; }
         public String LineColorPhrame { get; set; }
+        public string BackgroundColor { get; set; }
+        public int BackgroundAlpha { get; set; }
+        public int ChartAlpha { get; set; }
         public ChartSettings.SortType TimeSortOrder { get; set; }
         public ChartSettings.OrientationType LabelOrientation { get; set; }
         public IChartFontSettings Font

--- a/PXWeb/Code/Settings/Interfaces/IChartSettings.cs
+++ b/PXWeb/Code/Settings/Interfaces/IChartSettings.cs
@@ -68,10 +68,26 @@ namespace PXWeb
         bool ShowSource { get; }
 
         /// <summary>
+        /// Color on the background
+        /// </summary>
+        string BackgroundColor { get; }
+
+        /// <summary>
+        /// Alpha of the color on the background
+        /// </summary>
+        int BackgroundAlpha { get; }
+
+
+        /// <summary>
         /// Color on the background in the graph
         /// </summary>
         string BackgroundColorGraphs { get; }
-        
+
+        /// <summary>
+        /// Alpha of the color on the background in the graph
+        /// </summary>
+        int ChartAlpha { get; }
+
         /// <summary>
         /// Line thickness on phrame 
         /// </summary>

--- a/PXWeb/Global.asax.cs
+++ b/PXWeb/Global.asax.cs
@@ -181,7 +181,9 @@ namespace PXWeb
             settings.LineThicknessPhrame = Settings.Current.Features.Charts.LineThicknessPhrame;
             settings.LogotypePath = Settings.Current.General.Paths.ImagesPath;
             settings.LineColorPhrame = Settings.Current.Features.Charts.LineColorPhrame;
-           
+            settings.BackgroundColor = Settings.Current.Features.Charts.BackgroundColor;
+            settings.BackgroundAlpha = Settings.Current.Features.Charts.BackgroundAlpha;
+            settings.ChartAlpha = Settings.Current.Features.Charts.ChartAlpha;
         }
 
         protected void Application_Start(object sender, EventArgs e)

--- a/PXWeb/Resources/Languages/pxlang.sv.xml
+++ b/PXWeb/Resources/Languages/pxlang.sv.xml
@@ -1037,6 +1037,12 @@
   <sentence name="PxWebAdminFeaturesChartsGeneralLineThicknessPhrameInfo" value="Välj linjetjockleken på ramen runt diagrammet. Om inget anges så visas ingen ram." />
   <sentence name="PxWebAdminFeaturesChartsGeneralBackgroundColorGraphs" value="Bakgrundsfärg diagram" />
   <sentence name="PxWebAdminFeaturesChartsGeneralBackgroundColorGraphsInfo" value="Välj bakgrundsfärg till diagram." />
+	<sentence name="PxWebAdminFeaturesChartsGeneralBackgroundColor" value="Bakgrundsfärg"/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralBackgroundColorInfo" value="Välj bakgrundsfärg"/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralBackgroundAlpha" value="Transparens bakgrund"/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralChartAlpha" value="Transparens diagram"/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralBackgroundAlphaInfo" value="Välj transparens för bakgrunden. Måste vara ett värde mellan 0 och 255 där 0 är helt genomskinlig."/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralChartAlphaInfo" value="Välj transparens för bakgrunden till diagrammet. Måste vara ett värde mellan 0 och 255 där 0 är helt genomskinlig."/>
   <sentence name="PxWebChartsSourceLabel" value="Källa:" />
   <sentence name="PxWebChartsSource" value="Statistiska centralbyrån (SCB)" />
   <sentence name="PxWebAdminFeaturesApiGeneralApiSettings" value="API inställningar" />

--- a/PXWeb/Resources/Languages/pxlang.xml
+++ b/PXWeb/Resources/Languages/pxlang.xml
@@ -1258,7 +1258,13 @@
   <sentence name="PxWebAdminFeaturesChartsGeneralLineThicknessPhrameInfo" value="Select line thickness of the frame around the chart. If not specified, so there will be no frame."/>
   <sentence name="PxWebAdminFeaturesChartsGeneralBackgroundColorGraphs" value="Background color chart"/>
   <sentence name="PxWebAdminFeaturesChartsGeneralBackgroundColorGraphsInfo" value="Choose a background color to the chart."/>
-  <sentence name="PxWebChartsSourceLabel" value="Source:" />
+	<sentence name="PxWebAdminFeaturesChartsGeneralBackgroundColor" value="Background color"/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralBackgroundColorInfo" value="Choose a background color behind the chart."/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralBackgroundAlpha" value="Background alpha"/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralBackgroundAlphaInfo" value="Choose alpha / transparency of the background. Must be a value between 0 and 255 where 0 is completely transparent and 255 opaque."/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralChartAlpha" value="Chart background alpha"/>
+	<sentence name="PxWebAdminFeaturesChartsGeneralChartAlphaInfo" value="Choose alpha / transparency of the chart background. Must be a value between 0 and 255 where 0 is completely transparent and 255 opaque."/>
+	<sentence name="PxWebChartsSourceLabel" value="Source:" />
 	 <sentence name="PxWebChartsSource" value="Statistics Sweden" />
 
 	 <sentence name="PxWebAdminFeaturesApiGeneralApiSettings" value="API settings" />


### PR DESCRIPTION
* Background color of the graph has been added as a setting
* Alpha values for controlling the transparency of both background and chart background has been added as settings

It is now possible to control the transparency of graphs, resolves #183  