### PR TITLE
Switched from using 6 small Serializer nugets to one.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+- Changed to the PcAxis.Serializers nuget package
 - Upgraded the Newtonsoft JSON library dependenvis to 13.0.1 due to a vulnerability issue
 - Fixed marking tips translation in Swedish
 - Fixed shortcut texts for file formats in commandbar

--- a/PCAxis.Api/PCAxis.Api.csproj
+++ b/PCAxis.Api/PCAxis.Api.csproj
@@ -109,9 +109,6 @@
     <Reference Include="PCAxis.Encryption, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PCAxis.Encryption.1.0.0\lib\netstandard2.0\PCAxis.Encryption.dll</HintPath>
     </Reference>
-    <Reference Include="PCAxis.Excel, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Excel.1.0.2\lib\netstandard2.0\PCAxis.Excel.dll</HintPath>
-    </Reference>
     <Reference Include="PCAxis.Menu, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PCAxis.Menu.1.0.1\lib\netstandard2.0\PCAxis.Menu.dll</HintPath>
     </Reference>
@@ -133,20 +130,11 @@
     <Reference Include="PCAxis.Query, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PcAxis.Query.1.0.2\lib\netstandard2.0\PCAxis.Query.dll</HintPath>
     </Reference>
-    <Reference Include="PCAxis.Sdmx, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Sdmx.1.0.1\lib\netstandard2.0\PCAxis.Sdmx.dll</HintPath>
-    </Reference>
-    <Reference Include="PCAxis.Serializers.JsonStat, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Serializers.JsonStat.1.0.5\lib\netstandard2.0\PCAxis.Serializers.JsonStat.dll</HintPath>
-    </Reference>
-    <Reference Include="PCAxis.Serializers.JsonStat2, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Serializers.JsonStat2.1.0.1\lib\netstandard2.0\PCAxis.Serializers.JsonStat2.dll</HintPath>
-    </Reference>
     <Reference Include="PCAxis.Sql, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PcAxis.Sql.1.1.3\lib\netstandard2.0\PCAxis.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="PX.Serializers.Json, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PX.Serializers.Json.1.0.1\lib\netstandard2.0\PX.Serializers.Json.dll</HintPath>
+    <Reference Include="Serializers, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Serializers.1.0.0\lib\netstandard2.0\Serializers.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/PCAxis.Api/Serializers/JsonSerializer.cs
+++ b/PCAxis.Api/Serializers/JsonSerializer.cs
@@ -20,7 +20,7 @@ namespace PCAxis.Api.Serializers
         public void Serialize(PCAxis.Paxiom.PXModel model, ResponseBucket cacheResponse)
         {
             cacheResponse.ContentType = "application/json; charset=" + System.Text.Encoding.UTF8.WebName;
-            PCAxis.Paxiom.IPXModelStreamSerializer serializer = new PX.Serializers.Json.JsonSerializer();
+            PCAxis.Paxiom.IPXModelStreamSerializer serializer = new PCAxis.Serializers.JsonSerializer();
 
             using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
             {

--- a/PCAxis.Api/Serializers/JsonStat2Seriaizer.cs
+++ b/PCAxis.Api/Serializers/JsonStat2Seriaizer.cs
@@ -13,7 +13,7 @@ namespace PCAxis.Api.Serializers
         public void Serialize(PCAxis.Paxiom.PXModel model, ResponseBucket cacheResponse)
         {
             cacheResponse.ContentType = "application/json; charset=" + System.Text.Encoding.UTF8.WebName;
-            PCAxis.Paxiom.IPXModelStreamSerializer serializer = new PCAxis.Serializers.JsonStat2.JsonStat2Serializer();
+            PCAxis.Paxiom.IPXModelStreamSerializer serializer = new PCAxis.Serializers.JsonStat2Serializer();
 
             using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
             {

--- a/PCAxis.Api/Serializers/JsonStatSeriaizer.cs
+++ b/PCAxis.Api/Serializers/JsonStatSeriaizer.cs
@@ -14,7 +14,7 @@ namespace PCAxis.Api.Serializers
         public void Serialize(PCAxis.Paxiom.PXModel model, ResponseBucket cacheResponse)
         {
             cacheResponse.ContentType = "application/json; charset=" + System.Text.Encoding.UTF8.WebName;
-            var jsonStatSerializer = new PCAxis.Serializers.JsonStat.JsonStatSerializer();
+            var jsonStatSerializer = new PCAxis.Serializers.JsonStatSerializer();
 
             var geoVariablesStr = ConfigurationManager.AppSettings["geoVariables"];
 

--- a/PCAxis.Api/Serializers/SdmxDataSerializer.cs
+++ b/PCAxis.Api/Serializers/SdmxDataSerializer.cs
@@ -13,7 +13,7 @@ namespace PCAxis.Api.Serializers
         public void Serialize(PCAxis.Paxiom.PXModel model, ResponseBucket cacheResponse)
         {
             cacheResponse.ContentType = "text/xml; charset=" + System.Text.Encoding.Default.WebName;
-            PCAxis.Paxiom.IPXModelStreamSerializer serializer = new PCAxis.Sdmx.SdmxDataSerializer();
+            PCAxis.Paxiom.IPXModelStreamSerializer serializer = new PCAxis.Serializers.SdmxDataSerializer();
 
             using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
             {

--- a/PCAxis.Api/Serializers/XlsxSerializer.cs
+++ b/PCAxis.Api/Serializers/XlsxSerializer.cs
@@ -18,7 +18,7 @@ namespace PCAxis.Api.Serializers
 
         public void Serialize(PCAxis.Paxiom.PXModel model, HttpResponse httpResponse)
         {
-            PCAxis.Excel.XlsxSerializer serializer = new PCAxis.Excel.XlsxSerializer();
+            PCAxis.Serializers.XlsxSerializer serializer = new PCAxis.Serializers.XlsxSerializer();
             serializer.InformationLevel = PCAxis.Paxiom.InformationLevelType.AllInformation;
             serializer.DoubleColumn = PCAxis.Paxiom.Settings.Files.DoubleColumnFile;
             httpResponse.AddHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; charset=" + System.Text.Encoding.Default.WebName);
@@ -34,7 +34,7 @@ namespace PCAxis.Api.Serializers
         public void Serialize(PCAxis.Paxiom.PXModel model, ResponseBucket cacheResponse)
         {
             cacheResponse.ContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; charset=" + System.Text.Encoding.Default.WebName;
-            PCAxis.Excel.XlsxSerializer serializer = new PCAxis.Excel.XlsxSerializer();
+            PCAxis.Serializers.XlsxSerializer serializer = new PCAxis.Serializers.XlsxSerializer();
             serializer.InformationLevel = PCAxis.Paxiom.InformationLevelType.AllInformation;
             serializer.DoubleColumn = PCAxis.Paxiom.Settings.Files.DoubleColumnFile;
 

--- a/PCAxis.Api/packages.config
+++ b/PCAxis.Api/packages.config
@@ -18,7 +18,6 @@
   <package id="PcAxis.Common" version="1.0.2" targetFramework="net461" />
   <package id="PcAxis.Core" version="1.0.3" targetFramework="net461" />
   <package id="PCAxis.Encryption" version="1.0.0" targetFramework="net461" />
-  <package id="PCAxis.Excel" version="1.0.2" targetFramework="net461" />
   <package id="PCAxis.Menu" version="1.0.1" targetFramework="net461" />
   <package id="PCAxis.Menu.ConfigDatamodelMenu" version="1.0.3" targetFramework="net461" />
   <package id="PCAxis.Menu.MsSqlDatamodelMenu" version="1.0.1" targetFramework="net461" />
@@ -26,11 +25,8 @@
   <package id="PCAxis.Metadata" version="1.0.1" targetFramework="net461" />
   <package id="PCAxis.PX.Core" version="1.0.2" targetFramework="net461" />
   <package id="PcAxis.Query" version="1.0.2" targetFramework="net461" />
-  <package id="PCAxis.Sdmx" version="1.0.1" targetFramework="net461" />
-  <package id="PCAxis.Serializers.JsonStat" version="1.0.5" targetFramework="net461" />
-  <package id="PCAxis.Serializers.JsonStat2" version="1.0.1" targetFramework="net461" />
+  <package id="PCAxis.Serializers" version="1.0.0" targetFramework="net461" />
   <package id="PcAxis.Sql" version="1.1.3" targetFramework="net461" />
-  <package id="PX.Serializers.Json" version="1.0.1" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="5.0.0" targetFramework="net461" />
   <package id="System.Data.Common" version="4.3.0" targetFramework="net461" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.5.0" targetFramework="net461" />

--- a/PCAxis.Excel.Web.Controls/ExcelSerializerCreator.cs
+++ b/PCAxis.Excel.Web.Controls/ExcelSerializerCreator.cs
@@ -11,8 +11,8 @@ namespace PCAxis.Excel.Web.Controls
 
         public Paxiom.IPXModelStreamSerializer Create(string fileInfo)
         {
-            PCAxis.Excel.XlsxSerializer ser;
-            ser = new XlsxSerializer();
+            PCAxis.Serializers.XlsxSerializer ser;
+            ser = new PCAxis.Serializers.XlsxSerializer();
 
             if (fileInfo.Equals("FileTypeExcelXDoubleColumn"))
             {

--- a/PCAxis.Excel.Web.Controls/PCAxis.Excel.Web.Controls.csproj
+++ b/PCAxis.Excel.Web.Controls/PCAxis.Excel.Web.Controls.csproj
@@ -71,11 +71,23 @@
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PCAxis.Common, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Common.1.0.1\lib\netstandard2.0\PCAxis.Common.dll</HintPath>
+    </Reference>
     <Reference Include="PCAxis.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PcAxis.Core.1.0.3\lib\netstandard2.0\PCAxis.Core.dll</HintPath>
     </Reference>
-    <Reference Include="PCAxis.Excel, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Excel.1.0.2\lib\netstandard2.0\PCAxis.Excel.dll</HintPath>
+    <Reference Include="PCAxis.Metadata, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Metadata.1.0.1\lib\netstandard2.0\PCAxis.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="PCAxis.Query, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Query.1.0.1\lib\netstandard2.0\PCAxis.Query.dll</HintPath>
+    </Reference>
+    <Reference Include="Serializers, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Serializers.1.0.0\lib\netstandard2.0\Serializers.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/PCAxis.Excel.Web.Controls/SaveAsXlsx.cs
+++ b/PCAxis.Excel.Web.Controls/SaveAsXlsx.cs
@@ -39,8 +39,8 @@ namespace PCAxis.Excel.Web.Controls
 
             using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
             {
-                PCAxis.Excel.XlsxSerializer ser;
-                ser = new XlsxSerializer();
+                PCAxis.Serializers.XlsxSerializer ser;
+                ser = new PCAxis.Serializers.XlsxSerializer();
 
                 if (this.SelectedFormat.Equals("FileTypeExcelXDoubleColumn"))
                 {

--- a/PCAxis.Excel.Web.Controls/packages.config
+++ b/PCAxis.Excel.Web.Controls/packages.config
@@ -5,8 +5,12 @@
   <package id="ExcelNumberFormat" version="1.1.0" targetFramework="net461" />
   <package id="log4net" version="2.0.12" targetFramework="net461" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
+  <package id="PCAxis.Common" version="1.0.1" targetFramework="net461" />
   <package id="PcAxis.Core" version="1.0.3" targetFramework="net461" />
-  <package id="PCAxis.Excel" version="1.0.2" targetFramework="net461" />
+  <package id="PCAxis.Metadata" version="1.0.1" targetFramework="net461" />
+  <package id="PCAxis.Query" version="1.0.1" targetFramework="net461" />
+  <package id="PCAxis.Serializers" version="1.0.0" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="5.0.0" targetFramework="net461" />
   <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="System.IO.Packaging" version="4.0.0" targetFramework="net461" />

--- a/PCAxis.Html5Table.Web.Controls/Html5TableSerializerCreator.cs
+++ b/PCAxis.Html5Table.Web.Controls/Html5TableSerializerCreator.cs
@@ -13,8 +13,8 @@ namespace PCAxis.Html5Table.Web.Controls
 
 		public Paxiom.IPXModelStreamSerializer Create(string fileInfo)
 		{
-			PCAxis.Html5Table.Html5TableSerializer ser;
-			ser = new Html5TableSerializer();
+			PCAxis.Serializers.Html5TableSerializer ser;
+			ser = new PCAxis.Serializers.Html5TableSerializer();
 
 			return ser;
 		}

--- a/PCAxis.Html5Table.Web.Controls/PCAxis.Html5Table.Web.Controls.csproj
+++ b/PCAxis.Html5Table.Web.Controls/PCAxis.Html5Table.Web.Controls.csproj
@@ -31,14 +31,35 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ClosedXML, Version=0.95.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClosedXML.0.95.4\lib\net46\ClosedXML.dll</HintPath>
+    </Reference>
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
+    </Reference>
+    <Reference Include="ExcelNumberFormat, Version=1.0.10.0, Culture=neutral, PublicKeyToken=23c6f5d73be07eca, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExcelNumberFormat.1.0.10\lib\net20\ExcelNumberFormat.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PCAxis.Common, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Common.1.0.1\lib\netstandard2.0\PCAxis.Common.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PcAxis.Core.1.0.3\lib\netstandard2.0\PCAxis.Core.dll</HintPath>
     </Reference>
-    <Reference Include="PCAxis.Html5Table, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Html5Table.1.0.2\lib\netstandard2.0\PCAxis.Html5Table.dll</HintPath>
+    <Reference Include="PCAxis.Metadata, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Metadata.1.0.1\lib\netstandard2.0\PCAxis.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="PCAxis.Query, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Query.1.0.1\lib\netstandard2.0\PCAxis.Query.dll</HintPath>
+    </Reference>
+    <Reference Include="Serializers, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Serializers.1.0.0\lib\netstandard2.0\Serializers.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -48,6 +69,14 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.0.1\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Packaging.4.0.0\lib\net46\System.IO.Packaging.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PCAxis.Html5Table.Web.Controls/SaveAsHtml5Table.cs
+++ b/PCAxis.Html5Table.Web.Controls/SaveAsHtml5Table.cs
@@ -21,8 +21,8 @@ namespace PCAxis.Html5Table.Web.Controls
         {
 			using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
 			{
-				PCAxis.Html5Table.Html5TableSerializer ser;
-				ser = new Html5TableSerializer();
+                PCAxis.Serializers.Html5TableSerializer ser;
+				ser = new PCAxis.Serializers.Html5TableSerializer();
 
 
 				ser.Serialize(PaxiomManager.PaxiomModel, stream);

--- a/PCAxis.Html5Table.Web.Controls/packages.config
+++ b/PCAxis.Html5Table.Web.Controls/packages.config
@@ -1,9 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ClosedXML" version="0.95.4" targetFramework="net461" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net461" />
+  <package id="ExcelNumberFormat" version="1.0.10" targetFramework="net461" />
   <package id="log4net" version="2.0.12" targetFramework="net461" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
+  <package id="PCAxis.Common" version="1.0.1" targetFramework="net461" />
   <package id="PcAxis.Core" version="1.0.3" targetFramework="net461" />
-  <package id="PCAxis.Html5Table" version="1.0.2" targetFramework="net461" />
+  <package id="PCAxis.Metadata" version="1.0.1" targetFramework="net461" />
+  <package id="PCAxis.Query" version="1.0.1" targetFramework="net461" />
+  <package id="PCAxis.Serializers" version="1.0.0" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="5.0.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net461" />
+  <package id="System.IO.Packaging" version="4.0.0" targetFramework="net461" />
   <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net461" />
   <package id="System.Security.Permissions" version="5.0.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net461" />

--- a/PCAxis.JsonStat.Web.Controls/JsonStatFileType.cs
+++ b/PCAxis.JsonStat.Web.Controls/JsonStatFileType.cs
@@ -21,8 +21,8 @@ namespace PCAxis.JsonStat.Web.Controls
         {
             using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
             {
-                PCAxis.Serializers.JsonStat.JsonStatSerializer ser;
-                ser = new Serializers.JsonStat.JsonStatSerializer();
+                PCAxis.Serializers.JsonStatSerializer ser;
+                ser = new PCAxis.Serializers.JsonStatSerializer();
 
                 var geoVariablesStr = ConfigurationManager.AppSettings["geoVariables"];
 

--- a/PCAxis.JsonStat.Web.Controls/JsonStatSerializerCreator.cs
+++ b/PCAxis.JsonStat.Web.Controls/JsonStatSerializerCreator.cs
@@ -11,7 +11,7 @@ namespace PCAxis.JsonStat.Web.Controls
     {
         public PCAxis.Paxiom.IPXModelStreamSerializer Create(string fileInfo)
         {
-            var ser = new PCAxis.Serializers.JsonStat.JsonStatSerializer();
+            var ser = new PCAxis.Serializers.JsonStatSerializer();
 
             var geoVariablesStr = ConfigurationManager.AppSettings["geoVariables"];
 

--- a/PCAxis.JsonStat.Web.Controls/PCAxis.JsonStat.Web.Controls.csproj
+++ b/PCAxis.JsonStat.Web.Controls/PCAxis.JsonStat.Web.Controls.csproj
@@ -33,11 +33,23 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ClosedXML, Version=0.95.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClosedXML.0.95.4\lib\net46\ClosedXML.dll</HintPath>
+    </Reference>
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
+    </Reference>
+    <Reference Include="ExcelNumberFormat, Version=1.0.10.0, Culture=neutral, PublicKeyToken=23c6f5d73be07eca, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExcelNumberFormat.1.0.10\lib\net20\ExcelNumberFormat.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PCAxis.Common, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Common.1.0.1\lib\netstandard2.0\PCAxis.Common.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PcAxis.Core.1.0.3\lib\netstandard2.0\PCAxis.Core.dll</HintPath>
@@ -45,8 +57,11 @@
     <Reference Include="PCAxis.Metadata, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PCAxis.Metadata.1.0.1\lib\netstandard2.0\PCAxis.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="PCAxis.Serializers.JsonStat, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Serializers.JsonStat.1.0.5\lib\netstandard2.0\PCAxis.Serializers.JsonStat.dll</HintPath>
+    <Reference Include="PCAxis.Query, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Query.1.0.1\lib\netstandard2.0\PCAxis.Query.dll</HintPath>
+    </Reference>
+    <Reference Include="Serializers, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Serializers.1.0.0\lib\netstandard2.0\Serializers.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -56,6 +71,14 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.0.1\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Packaging.4.0.0\lib\net46\System.IO.Packaging.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PCAxis.JsonStat.Web.Controls/packages.config
+++ b/PCAxis.JsonStat.Web.Controls/packages.config
@@ -1,11 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ClosedXML" version="0.95.4" targetFramework="net461" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net461" />
+  <package id="ExcelNumberFormat" version="1.0.10" targetFramework="net461" />
   <package id="log4net" version="2.0.12" targetFramework="net461" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
+  <package id="PCAxis.Common" version="1.0.1" targetFramework="net461" />
   <package id="PcAxis.Core" version="1.0.3" targetFramework="net461" />
   <package id="PCAxis.Metadata" version="1.0.1" targetFramework="net461" />
-  <package id="PCAxis.Serializers.JsonStat" version="1.0.5" targetFramework="net461" />
+  <package id="PCAxis.Query" version="1.0.1" targetFramework="net461" />
+  <package id="PCAxis.Serializers" version="1.0.0" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="5.0.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net461" />
+  <package id="System.IO.Packaging" version="4.0.0" targetFramework="net461" />
   <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net461" />
   <package id="System.Security.Permissions" version="5.0.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net461" />

--- a/PCAxis.JsonStat2.Web.Controls/JsonStat2FileType.cs
+++ b/PCAxis.JsonStat2.Web.Controls/JsonStat2FileType.cs
@@ -21,8 +21,8 @@ namespace PCAxis.JsonStat2.Web.Controls
         {
             using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
             {
-                PCAxis.Serializers.JsonStat2.JsonStat2Serializer ser;
-                ser = new Serializers.JsonStat2.JsonStat2Serializer();
+                PCAxis.Serializers.JsonStat2Serializer ser;
+                ser = new PCAxis.Serializers.JsonStat2Serializer();
 
                 //var geoVariablesStr = ConfigurationManager.AppSettings["geoVariables"];
 

--- a/PCAxis.JsonStat2.Web.Controls/JsonStat2SerializerCreator.cs
+++ b/PCAxis.JsonStat2.Web.Controls/JsonStat2SerializerCreator.cs
@@ -11,7 +11,7 @@ namespace PCAxis.JsonStat2.Web.Controls
     {
         public PCAxis.Paxiom.IPXModelStreamSerializer Create(string fileInfo)
         {
-            var ser = new PCAxis.Serializers.JsonStat2.JsonStat2Serializer();
+            var ser = new PCAxis.Serializers.JsonStat2Serializer();
 
             //var geoVariablesStr = ConfigurationManager.AppSettings["geoVariables"];
 

--- a/PCAxis.JsonStat2.Web.Controls/PCAxis.JsonStat2.Web.Controls.csproj
+++ b/PCAxis.JsonStat2.Web.Controls/PCAxis.JsonStat2.Web.Controls.csproj
@@ -30,11 +30,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ClosedXML, Version=0.95.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClosedXML.0.95.4\lib\net46\ClosedXML.dll</HintPath>
+    </Reference>
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
+    </Reference>
+    <Reference Include="ExcelNumberFormat, Version=1.0.10.0, Culture=neutral, PublicKeyToken=23c6f5d73be07eca, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExcelNumberFormat.1.0.10\lib\net20\ExcelNumberFormat.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PCAxis.Common, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Common.1.0.1\lib\netstandard2.0\PCAxis.Common.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PcAxis.Core.1.0.3\lib\netstandard2.0\PCAxis.Core.dll</HintPath>
@@ -42,8 +54,11 @@
     <Reference Include="PCAxis.Metadata, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PCAxis.Metadata.1.0.1\lib\netstandard2.0\PCAxis.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="PCAxis.Serializers.JsonStat2, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Serializers.JsonStat2.1.0.5\lib\netstandard2.0\PCAxis.Serializers.JsonStat2.dll</HintPath>
+    <Reference Include="PCAxis.Query, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Query.1.0.1\lib\netstandard2.0\PCAxis.Query.dll</HintPath>
+    </Reference>
+    <Reference Include="Serializers, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Serializers.1.0.0\lib\netstandard2.0\Serializers.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -53,6 +68,14 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.0.1\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Packaging.4.0.0\lib\net46\System.IO.Packaging.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PCAxis.JsonStat2.Web.Controls/packages.config
+++ b/PCAxis.JsonStat2.Web.Controls/packages.config
@@ -1,11 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ClosedXML" version="0.95.4" targetFramework="net461" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net461" />
+  <package id="ExcelNumberFormat" version="1.0.10" targetFramework="net461" />
   <package id="log4net" version="2.0.12" targetFramework="net461" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
+  <package id="PCAxis.Common" version="1.0.1" targetFramework="net461" />
   <package id="PcAxis.Core" version="1.0.3" targetFramework="net461" />
   <package id="PCAxis.Metadata" version="1.0.1" targetFramework="net461" />
-  <package id="PCAxis.Serializers.JsonStat2" version="1.0.5" targetFramework="net461" />
+  <package id="PCAxis.Query" version="1.0.1" targetFramework="net461" />
+  <package id="PCAxis.Serializers" version="1.0.0" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="5.0.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net461" />
+  <package id="System.IO.Packaging" version="4.0.0" targetFramework="net461" />
   <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net461" />
   <package id="System.Security.Permissions" version="5.0.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net461" />

--- a/PX.Json.Web.Controls/JsonSerializerCreator.cs
+++ b/PX.Json.Web.Controls/JsonSerializerCreator.cs
@@ -11,8 +11,8 @@ namespace PX.Json.Web.Controls
     {
         public IPXModelStreamSerializer Create(string fileInfo)
         {
-            PX.Serializers.Json.JsonSerializer ser;
-            ser = new Serializers.Json.JsonSerializer();
+            PCAxis.Serializers.JsonSerializer ser;
+            ser = new PCAxis.Serializers.JsonSerializer();
 
             return ser;
         }

--- a/PX.Json.Web.Controls/PX.Json.Web.Controls.csproj
+++ b/PX.Json.Web.Controls/PX.Json.Web.Controls.csproj
@@ -30,6 +30,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ClosedXML, Version=0.95.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClosedXML.0.95.4\lib\net46\ClosedXML.dll</HintPath>
+    </Reference>
+    <Reference Include="DocumentFormat.OpenXml, Version=2.7.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.2.7.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
+    </Reference>
+    <Reference Include="ExcelNumberFormat, Version=1.0.10.0, Culture=neutral, PublicKeyToken=23c6f5d73be07eca, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExcelNumberFormat.1.0.10\lib\net20\ExcelNumberFormat.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
@@ -42,11 +51,14 @@
     <Reference Include="PCAxis.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PcAxis.Core.1.0.3\lib\netstandard2.0\PCAxis.Core.dll</HintPath>
     </Reference>
+    <Reference Include="PCAxis.Metadata, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Metadata.1.0.1\lib\netstandard2.0\PCAxis.Metadata.dll</HintPath>
+    </Reference>
     <Reference Include="PCAxis.Query, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\PcAxis.Query.1.0.2\lib\netstandard2.0\PCAxis.Query.dll</HintPath>
     </Reference>
-    <Reference Include="PX.Serializers.Json, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PX.Serializers.Json.1.0.1\lib\netstandard2.0\PX.Serializers.Json.dll</HintPath>
+    <Reference Include="Serializers, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PCAxis.Serializers.1.0.0\lib\netstandard2.0\Serializers.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -56,6 +68,14 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.0.1\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Packaging.4.0.0\lib\net46\System.IO.Packaging.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/PX.Json.Web.Controls/SaveAsJson.cs
+++ b/PX.Json.Web.Controls/SaveAsJson.cs
@@ -20,8 +20,8 @@ namespace PX.Json.Web.Controls
         {
             using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
             {
-                PX.Serializers.Json.JsonSerializer ser;
-                ser = new Serializers.Json.JsonSerializer();
+                PCAxis.Serializers.JsonSerializer ser;
+                ser = new PCAxis.Serializers.JsonSerializer();
                 
                 
                 ser.Serialize(PaxiomManager.PaxiomModel, stream);

--- a/PX.Json.Web.Controls/packages.config
+++ b/PX.Json.Web.Controls/packages.config
@@ -1,12 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ClosedXML" version="0.95.4" targetFramework="net461" />
+  <package id="DocumentFormat.OpenXml" version="2.7.2" targetFramework="net461" />
+  <package id="ExcelNumberFormat" version="1.0.10" targetFramework="net461" />
   <package id="log4net" version="2.0.12" targetFramework="net461" />
+  <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="PcAxis.Common" version="1.0.2" targetFramework="net461" />
   <package id="PcAxis.Core" version="1.0.3" targetFramework="net461" />
+  <package id="PCAxis.Metadata" version="1.0.1" targetFramework="net461" />
   <package id="PcAxis.Query" version="1.0.2" targetFramework="net461" />
-  <package id="PX.Serializers.Json" version="1.0.1" targetFramework="net461" />
+  <package id="PCAxis.Serializers" version="1.0.0" targetFramework="net461" />
   <package id="System.Configuration.ConfigurationManager" version="5.0.0" targetFramework="net461" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.1" targetFramework="net461" />
+  <package id="System.IO.Packaging" version="4.0.0" targetFramework="net461" />
   <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net461" />
   <package id="System.Security.Permissions" version="5.0.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net461" />


### PR DESCRIPTION
Noticed a bit too late that https://github.com/statisticssweden/PxWeb/issues/163 said ".. All namespaces will be remain as they are to avoid extra work.". They are changed here.

(The buildToAzure breaks in build of PxWeb.Test, as it has TargetFramework netcoreapp3.1)