### PR TITLE
Update deploy_to_azure.yml

### DIFF
--- a/.github/workflows/deploy_to_azure.yml
+++ b/.github/workflows/deploy_to_azure.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
   
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Changed runs-on:  from lastest to 2019.
Google said that "The reference assemblies for .NETFramework,Version=v4.6.1 were not found." came with 2022. We have a ticket on moving from 4.6.1 
I ran the action from the patch branch and it completes ok