### PR TITLE
Removed no-store from the Cache-Control header 

### DIFF
--- a/TemplateConfigFiles/Web.config
+++ b/TemplateConfigFiles/Web.config
@@ -434,7 +434,7 @@
 		<add name="Referrer-Policy" value="same-origin" />
         
         <!-- The Cache-Control HTTP header field holds directives — in both requests and responses — that control caching in browsers and shared caches -->
-        <add name="Cache-Control" value="no-cache, no-store, must-revalidate Pragma: no-cache Expires: 0"/>
+		<add name="Cache-Control" value="no-cache, must-revalidate Pragma: no-cache Expires: 0"/>
 		  
         <!--informs browsers that the site should only be accessed using HTTPS -->		  
 	<add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains; preload"/>		  


### PR DESCRIPTION
Removed no-store from the Cache-Control header to make the browser back-button work