### PR TITLE
Change save location of DCAT-AP XML file.

### DIFF
--- a/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
+++ b/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
@@ -170,10 +170,10 @@ namespace PXWeb.Admin
             }
             string themeMapping = HttpContext.Current.Server.MapPath("~/TMapping.json");
             string dbType = cboSelectDbType.SelectedItem.Value;
-            string dbid = "";
+            string dbid;
             IFetcher fetcher;
 
-            string currPath = HttpContext.Current.Server.MapPath("~");
+            string savePath = HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/" + cboSelectDb.SelectedItem.Value + "/dcat-ap.xml");
 
             switch (dbType) {
                 case "PX":
@@ -212,7 +212,7 @@ namespace PXWeb.Admin
             };
             try
             {
-                XML.WriteToFile(HttpContext.Current.Server.MapPath("~/dcat-ap.xml"), settings);
+                XML.WriteToFile(savePath, settings);
             }
             catch(PCAxis.Menu.Exceptions.InvalidMenuFromXMLException)
             {

--- a/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
+++ b/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
@@ -173,8 +173,7 @@ namespace PXWeb.Admin
             string dbid;
             IFetcher fetcher;
 
-            string savePath = HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/" + cboSelectDb.SelectedItem.Value + "/dcat-ap.xml");
-
+            string savePath = HttpContext.Current.Server.MapPath(PXWeb.Settings.Current.General.Paths.PxDatabasesPath + cboSelectDb.SelectedItem.Value + "/dcat-ap.xml");
             switch (dbType) {
                 case "PX":
                     dbid = HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/") + cboSelectDb.SelectedItem.Value + "/Menu.xml";

--- a/PXWeb/Code/API/Controllers/DcatController.cs
+++ b/PXWeb/Code/API/Controllers/DcatController.cs
@@ -37,17 +37,17 @@ namespace PXWeb.API
                 }
                 else if(databaseTypeLower == "px")
                 {
-                    settings.DBid = HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/") + database + "/Menu.xml";
+                    settings.DBid = HttpContext.Current.Server.MapPath(PXWeb.Settings.Current.General.Paths.PxDatabasesPath) + database + "/Menu.xml";
                     if (!File.Exists(settings.DBid)) return Request.CreateResponse(HttpStatusCode.BadRequest, $"Database does not exist: {database}");
-                    string localThemeMapping = HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/") + database + "/TMapping.json";
+                    string localThemeMapping = HttpContext.Current.Server.MapPath(PXWeb.Settings.Current.General.Paths.PxDatabasesPath) + database + "/TMapping.json";
                     if (File.Exists(localThemeMapping)) settings.ThemeMapping = localThemeMapping;
-                    settings.Fetcher = new PXFetcher(HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/"));
+                    settings.Fetcher = new PXFetcher(HttpContext.Current.Server.MapPath(PXWeb.Settings.Current.General.Paths.PxDatabasesPath));
                 }
                 else
                 {
                     return Request.CreateResponse(HttpStatusCode.BadRequest, $"Invalid database type");
                 }
-                string savePath = HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/" + database + "/dcat-ap.xml");
+                string savePath = HttpContext.Current.Server.MapPath(PXWeb.Settings.Current.General.Paths.PxDatabasesPath + database + "/dcat-ap.xml");
                 XML.WriteToFile(savePath, settings);
                 return Request.CreateResponse(HttpStatusCode.OK, $"Xml file created successfully, {databaseType}");
             }

--- a/PXWeb/Code/API/Controllers/DcatController.cs
+++ b/PXWeb/Code/API/Controllers/DcatController.cs
@@ -47,7 +47,8 @@ namespace PXWeb.API
                 {
                     return Request.CreateResponse(HttpStatusCode.BadRequest, $"Invalid database type");
                 }
-                XML.WriteToFile(HttpContext.Current.Server.MapPath("~/dcat-ap.xml"), settings);
+                string savePath = HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/" + database + "/dcat-ap.xml");
+                XML.WriteToFile(savePath, settings);
                 return Request.CreateResponse(HttpStatusCode.OK, $"Xml file created successfully, {databaseType}");
             }
         }


### PR DESCRIPTION
The file created with the DataportalXML module is now saved in the folder of the corresponding database, located in the [databases](https://github.com/statisticssweden/PxWeb/tree/master/PXWeb/Resources/PX/Databases) folder. 

Using the DataportalXML tool on the Example database would result in a dcat-ap.xml file in [PXWeb/Resources/PX/Databases/Example](https://github.com/statisticssweden/PxWeb/tree/master/PXWeb/Resources/PX/Databases/Example)