### PR TITLE
Update ResponseMapper.cs

### DIFF
--- a/PxWeb/Mappers/ResponseMapper.cs
+++ b/PxWeb/Mappers/ResponseMapper.cs
@@ -11,7 +11,7 @@ namespace PxWeb.Mappers
     {
         public Folder GetFolder(PxMenuItem currentItem, HttpContext httpContext)
         {
-            string urlBase = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}/v2/";
+            string urlBase = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}/api/v2/";
             Folder folder = new Folder
             {
                 Id = Path.GetFileName(currentItem.ID.Selection),


### PR DESCRIPTION
Seems to give the correct hrefs?
"links": [
{
"rel": "folder",
"href": "https://localhost:51108/api/v2/navigation/al"
}
]

