### PR TITLE
Add middleware to check for whitelisted IPs and admin header key

### DIFF
--- a/PXWeb/Config/Api2/AdminProtectionConfigurationOptions.cs
+++ b/PXWeb/Config/Api2/AdminProtectionConfigurationOptions.cs
@@ -5,5 +5,6 @@ namespace PxWeb.Config.Api2
     public class AdminProtectionConfigurationOptions
     {
         public List<string> IpWhitelist { get; set; } = new List<string>();
+        public string AdminKey { get; set; } = string.Empty;
     }
 }

--- a/PXWeb/Config/Api2/AdminProtectionConfigurationOptions.cs
+++ b/PXWeb/Config/Api2/AdminProtectionConfigurationOptions.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace PxWeb.Config.Api2
+{
+    public class AdminProtectionConfigurationOptions
+    {
+        public List<string> IpWhitelist { get; set; } = new List<string>();
+    }
+}

--- a/PXWeb/Config/Api2/AdminProtectionConfigurationService.cs
+++ b/PXWeb/Config/Api2/AdminProtectionConfigurationService.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+
+namespace PxWeb.Config.Api2
+{
+    public class AdminProtectionConfigurationService : IAdminProtectionConfigurationService
+    {
+        private readonly AdminProtectionConfigurationOptions _adminProtectionOptions;
+        public AdminProtectionConfigurationService(IOptions<AdminProtectionConfigurationOptions> adminProtectionOptions)
+        {
+            _adminProtectionOptions = adminProtectionOptions.Value;
+        }
+
+        public AdminProtectionConfigurationOptions GetConfiguration()
+        {
+            return _adminProtectionOptions;
+        }
+    }
+}

--- a/PXWeb/Config/Api2/IAdminProtectionConfigurationService.cs
+++ b/PXWeb/Config/Api2/IAdminProtectionConfigurationService.cs
@@ -1,0 +1,7 @@
+﻿namespace PxWeb.Config.Api2
+{
+    public interface IAdminProtectionConfigurationService
+    {
+        AdminProtectionConfigurationOptions GetConfiguration();
+    }
+}

--- a/PXWeb/Middleware/AdminProtectionIpWhitelistMiddleware.cs
+++ b/PXWeb/Middleware/AdminProtectionIpWhitelistMiddleware.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+using PxWeb.Config.Api2;
+using System.Collections.Generic;
+
+namespace PxWeb.Middleware
+{
+    // You may need to install the Microsoft.AspNetCore.Http.Abstractions package into your project
+    public class AdminProtectionIpWhitelistMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IAdminProtectionConfigurationService _adminProtectionConfigurationService;
+
+        public AdminProtectionIpWhitelistMiddleware(RequestDelegate next, IAdminProtectionConfigurationService adminProtectionConfigurationService)
+        {
+            _next = next;
+            _adminProtectionConfigurationService = adminProtectionConfigurationService;
+        }
+
+        public Task Invoke(HttpContext httpContext)
+        {
+            AdminProtectionConfigurationOptions options = _adminProtectionConfigurationService.GetConfiguration();
+            List<string> ipWhitelist = options.IpWhitelist;
+            return _next(httpContext);
+        }
+    }
+
+    // Extension method used to add the middleware to the HTTP request pipeline.
+    public static class MiddlewareExtensions
+    {
+        public static IApplicationBuilder UseAdminProtectionIpWhitelist(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<AdminProtectionIpWhitelistMiddleware>();
+        }
+    }
+}

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -21,6 +21,7 @@ using PxWeb.Mappers;
 using Newtonsoft.Json;
 using System;
 using PxWeb.Code.Api2.NewtonsoftConfiguration;
+using PxWeb.Middleware;
 
 namespace PxWeb
 {
@@ -57,8 +58,11 @@ namespace PxWeb
             builder.Services.AddPxDataSource(builder);
 
             builder.Services.Configure<PxApiConfigurationOptions>(builder.Configuration.GetSection("PxApiConfiguration"));
+            builder.Services.Configure<AdminProtectionConfigurationOptions>(builder.Configuration.GetSection("AdminProtection"));
+
             
             builder.Services.AddTransient<IPxApiConfigurationService, PxApiConfigurationService>();
+            builder.Services.AddTransient<IAdminProtectionConfigurationService, AdminProtectionConfigurationService>();
             builder.Services.AddTransient<ILanguageHelper, LanguageHelper>();
             builder.Services.AddTransient<IResponseMapper, ResponseMapper>();
 
@@ -104,7 +108,6 @@ namespace PxWeb
                 app.UseSwagger();
                 app.UseSwaggerUI();
             //}
-
             app.UseHttpsRedirection();
 
             if (corsEnbled)

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -102,6 +102,7 @@ namespace PxWeb
 
             var app = builder.Build();
 
+
             // Configure the HTTP request pipeline.
             //if (app.Environment.IsDevelopment())
             //{
@@ -116,6 +117,11 @@ namespace PxWeb
             }
 
             app.UseAuthorization();
+
+            app.UseWhen(context => context.Request.Path.StartsWithSegments("/api/v2/admin"), appBuilder =>
+            {
+                appBuilder.UseAdminProtectionIpWhitelist();
+            });
 
             app.MapControllers();
 

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -134,5 +134,4 @@ namespace PxWeb
             app.Run();
         }
     }
-
 }

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -121,6 +121,7 @@ namespace PxWeb
             app.UseWhen(context => context.Request.Path.StartsWithSegments("/api/v2/admin"), appBuilder =>
             {
                 appBuilder.UseAdminProtectionIpWhitelist();
+                appBuilder.UseAdminProtectionKey();
             });
 
             app.MapControllers();

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -42,7 +42,7 @@
     "CacheTime": 10
   },
   "AdminProtection": {
-    "IpWhitelist": [ "127.0.0.1" ]
+    "IpWhitelist": [ "127.0.0.1", "::1" ]
   },
   "IpRateLimiting": {
     "EnableEndpointRateLimiting": false,

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -41,6 +41,9 @@
     },
     "CacheTime": 10
   },
+  "AdminProtection": {
+    "IpWhitelist": [ "127.0.0.1" ]
+  },
   "IpRateLimiting": {
     "EnableEndpointRateLimiting": false,
     "StackBlockedRequests": false,

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -42,7 +42,8 @@
     "CacheTime": 10
   },
   "AdminProtection": {
-    "IpWhitelist": [ "127.0.0.1", "::1" ]
+    "IpWhitelist": [ "127.0.0.1", "::1" ],
+    "AdminKey" :  "test"
   },
   "IpRateLimiting": {
     "EnableEndpointRateLimiting": false,


### PR DESCRIPTION
When a request is sent to an "api/v2/admin/*" endpoint, the IP-address is checked by middleware to be whitelisted in appsettings. If not, the request is rejected.  Another middleware checks for a "API_ADMIN_KEY" header in the request, this header must match the value in appsettings. 
https://github.com/statisticssweden/PxWeb/blob/e1fc72bad6a9c0b683a1e9a7c6840ca6bf0f5f82/PxWeb/appsettings.json#L44-L47