### PR TITLE
Add endpoint for PxCache

### DIFF
--- a/PXWeb/Controllers/Api2/Admin/CacheController.cs
+++ b/PXWeb/Controllers/Api2/Admin/CacheController.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using PxWeb.Code.Api2.Cache;
+
+namespace PxWeb.Controllers.Api2.Admin
+{
+    [ApiController]
+    public class CacheController : ControllerBase
+    {
+        private readonly IPxCache _pxCache;
+
+        public CacheController(IPxCache pxCache)
+        {
+            _pxCache = pxCache;
+        }
+
+        [HttpDelete]
+        [Route("/api/v2/admin/cache")]
+        public IActionResult Clear()
+        {
+            _pxCache.Clear();
+            return Ok();
+        }
+    }
+}

--- a/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
+++ b/PxWeb/Code/Api2/DataSource/Cnmm/ItemSelectionResolverCnmm.cs
@@ -4,39 +4,35 @@ using System.IO;
 using Microsoft.Extensions.Caching.Memory;
 using PCAxis.Menu;
 using Px.Abstractions.Interfaces;
+using PxWeb.Code.Api2.Cache;
 using PxWeb.Config.Api2;
 
 namespace PxWeb.Code.Api2.DataSource.Cnmm
 {
     public class ItemSelectionResolverCnmm : IItemSelectionResolver
     {
-        private readonly IMemoryCache _memoryCache;
+        private readonly IPxCache _pxCache;
         private readonly IItemSelectionResolverFactory _itemSelectionResolverFactory;
         private readonly IPxApiConfigurationService _pxApiConfigurationService;
 
-        public ItemSelectionResolverCnmm(IMemoryCache memoryCache, IItemSelectionResolverFactory itemSelectionResolverFactory, IPxApiConfigurationService pxApiConfigurationService)
+        public ItemSelectionResolverCnmm(IPxCache pxCache, IItemSelectionResolverFactory itemSelectionResolverFactory, IPxApiConfigurationService pxApiConfigurationService)
         {
-            _memoryCache = memoryCache;
+            _pxCache = pxCache;
             _itemSelectionResolverFactory = itemSelectionResolverFactory;
             _pxApiConfigurationService = pxApiConfigurationService;
         }
 
         public ItemSelection Resolve(string language, string selection, out bool selectionExists)
         {
-            var op = _pxApiConfigurationService.GetConfiguration();
-
             selectionExists = true;
             ItemSelection itemSelection = new ItemSelection();
 
             string lookupTableName = "LookUpTableCache_" + language;
-            if (!_memoryCache.TryGetValue(lookupTableName, out Dictionary<string, string> lookupTable))
+            var lookupTable = _pxCache.Get<Dictionary<string, string>>(lookupTableName);
+            if (lookupTable is null)
             {
                 lookupTable = _itemSelectionResolverFactory.GetMenuLookup(language);
-
-                var cacheEntryOptions = new MemoryCacheEntryOptions()
-                    .SetSlidingExpiration(TimeSpan.FromMinutes(op.CacheTime));
-
-                _memoryCache.Set(lookupTableName, lookupTable, cacheEntryOptions);
+                _pxCache.Set(lookupTableName, lookupTable);
             }
 
             if (!string.IsNullOrEmpty(selection))


### PR DESCRIPTION
* Endpoint created under api/v2/admin/cache, a DELETE request will clear the IPxCache singleton
* Instances of IMemoryCache now use IPxCache instead

Builds on changes made in #267 