### PR TITLE
Add separate cache time variable for middleware

### DIFF
--- a/PxWeb/Code/Api2/Cache/IPxCache.cs
+++ b/PxWeb/Code/Api2/Cache/IPxCache.cs
@@ -15,6 +15,7 @@ namespace PxWeb.Code.Api2.Cache
         void Enable();
         T? Get<T>(object key);
         void Set(object key, object value);
+        void Set(object key, object value, TimeSpan lifetime);
 
     }
 }

--- a/PxWeb/Code/Api2/Cache/PxCache.cs
+++ b/PxWeb/Code/Api2/Cache/PxCache.cs
@@ -80,6 +80,15 @@ namespace PxWeb.Code.Api2.Cache
         /// <param name="data"></param>
         public void Set(object key, object value)
         {
+            Set(key, value, _cacheTime);
+        }
+
+        /// <summary>
+        /// Stores a object in the cache for a specified time
+        /// </summary>
+        /// <param name="data"></param>
+        public void Set(object key, object value, TimeSpan lifetime)
+        {
             if (_cache.Get(key) is null)
             {
                 _logger.LogDebug("Adding key={0} to Cache", key);
@@ -88,7 +97,7 @@ namespace PxWeb.Code.Api2.Cache
                 {
                     if (_cache.Get(key) is null)
                     {
-                        _cache.Set(key, value, _cacheTime);
+                        _cache.Set(key, value, lifetime);
                     }
                 }
             }

--- a/PxWeb/Config/Api2/CacheMiddlewareConfigurationOptions.cs
+++ b/PxWeb/Config/Api2/CacheMiddlewareConfigurationOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace PxWeb.Config.Api2
+{
+    public class CacheMiddlewareConfigurationOptions
+    {
+        public int CacheTime { get; set; } = 10;
+    }
+}

--- a/PxWeb/Config/Api2/CacheMiddlewareConfigurationService.cs
+++ b/PxWeb/Config/Api2/CacheMiddlewareConfigurationService.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+
+namespace PxWeb.Config.Api2
+{
+    public class CacheMiddlewareConfigurationService : ICacheMiddlewareConfigurationService
+    {
+        private readonly CacheMiddlewareConfigurationOptions _cacheMiddlewareConfigurationOptions;
+        public CacheMiddlewareConfigurationService(IOptions<CacheMiddlewareConfigurationOptions> cacheMiddlewareConfigurationOptions)
+        {
+            _cacheMiddlewareConfigurationOptions = cacheMiddlewareConfigurationOptions.Value;
+        }
+
+        public CacheMiddlewareConfigurationOptions GetConfiguration()
+        {
+            return _cacheMiddlewareConfigurationOptions;
+        }
+    }
+}

--- a/PxWeb/Config/Api2/ICacheMiddlewareConfigurationService.cs
+++ b/PxWeb/Config/Api2/ICacheMiddlewareConfigurationService.cs
@@ -1,0 +1,7 @@
+﻿namespace PxWeb.Config.Api2
+{
+    public interface ICacheMiddlewareConfigurationService
+    {
+        CacheMiddlewareConfigurationOptions GetConfiguration();
+    }
+}

--- a/PxWeb/Middleware/CacheMiddleware.cs
+++ b/PxWeb/Middleware/CacheMiddleware.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 using System.IO;
 using System;
+using PxWeb.Config.Api2;
 using PxWeb.Code.Api2.Cache;
 
 namespace PxWeb.Middleware
@@ -12,10 +13,14 @@ namespace PxWeb.Middleware
     {
         private readonly RequestDelegate _next;
         private string _cacheLock = "lock";
+        CacheMiddlewareConfigurationOptions _configuration;
+        private TimeSpan _cacheTime;
 
-        public CacheMiddleware(RequestDelegate next)
+        public CacheMiddleware(RequestDelegate next, ICacheMiddlewareConfigurationService cacheMiddlewareConfigurationService)
         {
             _next = next;
+            _configuration = cacheMiddlewareConfigurationService.GetConfiguration();
+            _cacheTime = TimeSpan.FromSeconds(_configuration.CacheTime);
         }
         private async Task<CachedResponse> readResponse(HttpContext httpContext)
         {
@@ -68,7 +73,7 @@ namespace PxWeb.Middleware
                     CachedResponse? freshCached = cache.Get<CachedResponse>(key);
                     if (freshCached is null)
                     {
-                        cache.Set(key, response);
+                        cache.Set(key, response, _cacheTime);
                     }
                     else
                     {

--- a/PxWeb/Program.cs
+++ b/PxWeb/Program.cs
@@ -67,10 +67,12 @@ namespace PxWeb
 
             builder.Services.Configure<PxApiConfigurationOptions>(builder.Configuration.GetSection("PxApiConfiguration"));
             builder.Services.Configure<AdminProtectionConfigurationOptions>(builder.Configuration.GetSection("AdminProtection"));
+            builder.Services.Configure<CacheMiddlewareConfigurationOptions>(builder.Configuration.GetSection("CacheMiddleware"));
 
-            
+
             builder.Services.AddTransient<IPxApiConfigurationService, PxApiConfigurationService>();
             builder.Services.AddTransient<IAdminProtectionConfigurationService, AdminProtectionConfigurationService>();
+            builder.Services.AddTransient<ICacheMiddlewareConfigurationService, CacheMiddlewareConfigurationService>();
             builder.Services.AddTransient<ILanguageHelper, LanguageHelper>();
             builder.Services.AddTransient<IResponseMapper, ResponseMapper>();
             builder.Services.AddTransient<IPxHost, PxWebHost>();
@@ -143,7 +145,10 @@ namespace PxWeb
                 app.UseIpRateLimiting();
             }
 
-            app.UseCacheMiddleware();
+            app.UseWhen(context => !context.Request.Path.StartsWithSegments("/api/v2/admin"), appBuilder =>
+            {
+                appBuilder.UseCacheMiddleware();
+            });
 
             app.Run();
         }

--- a/PxWeb/appsettings.json
+++ b/PxWeb/appsettings.json
@@ -38,7 +38,7 @@
       "Enabled": true,
       "Origins": "*"
     },
-    "CacheTime": 10,
+    "CacheTime": 86400,
     "SearchEngine": "Lucene",
     "PageSize":  20
   },
@@ -47,7 +47,10 @@
   },
   "AdminProtection": {
     "IpWhitelist": [ "127.0.0.1", "::1" ],
-    "AdminKey" :  "test"
+    "AdminKey": "test"
+  },
+  "CacheMiddleware": {
+    "CacheTime": 10
   },
   "IpRateLimiting": {
     "EnableEndpointRateLimiting": false,


### PR DESCRIPTION
* Cache middleware now has a separate variable for cache lifetime in appsettings.
* Cache middleware is not invoked for admin endpoints