### PR TITLE
Dcat tool as background process

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 === Release of PxWeb 2023 v1 ===
+- Dcat admin tool settings are now saved separately for each database, in the corresponding database.config file
+- Dcat admin tool now uses the BackgroundWorker to run tasks as background processes
 - Upgraded versions of nuget-packages
 - Now possible to set CNMM database rootnode
 - Updated template web.config with new assembly reference and new version number

--- a/PXWeb/Admin/Tools-XMLGenerator.aspx
+++ b/PXWeb/Admin/Tools-XMLGenerator.aspx
@@ -12,7 +12,7 @@
     </div>
     <div class="setting-field">
         <asp:Label ID="lblSelectDb" runat="server" Text="<%$ PxString: PxWebAdminToolsXMLGeneratorSelectDb %>">"></asp:Label>
-        <asp:DropDownList ID="cboSelectDb" runat="server"></asp:DropDownList>
+        <asp:DropDownList ID="cboSelectDb" onselectedindexchanged="cboSelectDb_SelectedIndexChanged" AutoPostBack="true" runat="server"></asp:DropDownList>
         <asp:ImageButton ID="imgSelectDbInfo" runat="server" onclick="imgSelectDb_Click" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>"/>
     </div>
     <div class="setting-field">
@@ -49,6 +49,11 @@
         <asp:Label ID="lblSelectPublisher" runat="server" Text="<%$ PxString: PxWebAdminToolsXMLGeneratorSelectPublisher %>">"></asp:Label>
         <asp:TextBox ID="textBoxSelectPublisher" runat="server"></asp:TextBox>
         <asp:ImageButton ID="imgSelectPublisher" runat="server" onclick="imgSelectPublisher_Click" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>"/>
+    </div>
+        <div class="setting-field">
+        <asp:Label ID="lblStatus" runat="server" Text="<%$ PxString: PxWebAdminToolsXMLGeneratorStatus %>">"></asp:Label>
+        <asp:Label ID="lblStatusValue" runat="server" Text="NotCreated"></asp:Label>
+        <asp:ImageButton ID="imgStatus" runat="server" onclick="imgStatus_Click" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>"/>
     </div>
 
      <div class="setting-field">

--- a/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
+++ b/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
@@ -177,6 +177,8 @@ namespace PXWeb.Admin
         {
             string dbid = cboSelectDb.Text;
 
+            saveCurrentSettings();
+
             PXWeb.DatabaseSettings db = (PXWeb.DatabaseSettings)PXWeb.Settings.Current.GetDatabase(dbid);
             PXWeb.DcatSettings dcatSettings = (PXWeb.DcatSettings)db.Dcat;
 

--- a/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
+++ b/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
@@ -134,6 +134,14 @@ namespace PXWeb.Admin
             textBoxSelectCatalogDesc.Text = dcatSettings.CatalogDescription;
             textBoxSelectLicense.Text = dcatSettings.License;
             updateStatusLabel(dcatSettings);
+
+            if (dcatSettings.FileStatus == DcatStatusType.Creating || dcatSettings.FileStatus == DcatStatusType.WaitingCreate) {
+                btnGenerateXML.Enabled = false;
+            }
+            else
+            {
+                btnGenerateXML.Enabled = true;
+            }
         }
 
         private void updateStatusLabel(DcatSettings dcatSettings)
@@ -181,6 +189,7 @@ namespace PXWeb.Admin
                 dcatSettings.FileStatus = DcatStatusType.WaitingCreate;
                 db.Save();
                 updateStatusLabel(dcatSettings);
+                btnGenerateXML.Enabled = false;
 
                 if (PXWeb.Settings.Current.Features.General.BackgroundWorkerEnabled)
                 {

--- a/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
+++ b/PXWeb/Admin/Tools-XMLGenerator.aspx.cs
@@ -49,6 +49,13 @@ namespace PXWeb.Admin
         {
             if (cboSelectDbType.SelectedItem.Value == "PX") fillPxDatabases(cboSelectDb);
             else fillCNMMDatabases(cboSelectDb);
+
+            ReadSettings(cboSelectDb.Text);
+        }
+
+        protected void cboSelectDb_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ReadSettings(cboSelectDb.Text);
         }
 
         protected void Page_Load(object sender, EventArgs e)
@@ -109,21 +116,9 @@ namespace PXWeb.Admin
             Master.ShowInfoDialog("PxWebAdminToolsXMLGeneratorSelectPublisher", "PxWebAdminToolsXMLGeneratorSelectPublisherInfo");
         }
 
-        /// <summary>
-        /// Read and display Charts settings  
-        /// </summary>
-        private void ReadSettings()
+        protected void imgStatus_Click(object sender, ImageClickEventArgs e)
         {
-
-            textBoxSelectBaseURI.Text = Settings.Current.Dcat.BaseURI;
-            textBoxSelectApiURL.Text = Settings.Current.Dcat.BaseApiUrl;
-            textBoxSelectLandingPageURL.Text = Settings.Current.Dcat.LandingPageUrl;
-            textBoxSelectPublisher.Text = Settings.Current.Dcat.Publisher;
-            textBoxSelectCatalogTitle.Text = Settings.Current.Dcat.CatalogTitle;
-            textBoxSelectCatalogDesc.Text = Settings.Current.Dcat.CatalogDescription;
-            cboSelectDb.Text = Settings.Current.Dcat.Database;
-            cboSelectDbType.Text = Settings.Current.Dcat.DatabaseType;
-            textBoxSelectLicense.Text = Settings.Current.Dcat.License;
+            Master.ShowInfoDialog("PxWebAdminToolsXMLGeneratorStatus", "PxWebAdminToolsXMLGeneratorStatusInfo");
         }
 
         private void ReadSettings(string database)
@@ -138,6 +133,16 @@ namespace PXWeb.Admin
             textBoxSelectCatalogTitle.Text = dcatSettings.CatalogTitle;
             textBoxSelectCatalogDesc.Text = dcatSettings.CatalogDescription;
             textBoxSelectLicense.Text = dcatSettings.License;
+            updateStatusLabel(dcatSettings);
+        }
+
+        private void updateStatusLabel(DcatSettings dcatSettings)
+        {
+            lblStatusValue.Text = dcatSettings.FileStatus.ToString();
+            if (dcatSettings.FileStatus == DcatStatusType.Created)
+            {
+                lblStatusValue.Text += " " + dcatSettings.FileUpdated.ToString();
+            }
         }
 
         private void saveCurrentSettings()
@@ -159,18 +164,6 @@ namespace PXWeb.Admin
         }
 
         protected void MasterSave_Click(object sender, EventArgs e) {
-            //if (Settings.BeginUpdate())
-            //{
-            //    try
-            //    {
-            //        DcatSettings dcats = getCurrentSettings();
-            //        Settings.Save();
-            //    }
-            //    finally
-            //    {
-            //        Settings.EndUpdate();
-            //    }
-            //}
             saveCurrentSettings();
         }
         protected void btnGenerateXML_Click(object sender, EventArgs e)
@@ -187,6 +180,7 @@ namespace PXWeb.Admin
             {
                 dcatSettings.FileStatus = DcatStatusType.WaitingCreate;
                 db.Save();
+                updateStatusLabel(dcatSettings);
 
                 if (PXWeb.Settings.Current.Features.General.BackgroundWorkerEnabled)
                 {
@@ -194,16 +188,6 @@ namespace PXWeb.Admin
                     BackgroundWorker.PxWebBackgroundWorker.WakeUp();
                 }
             }
-
-            //try
-            //{
-            //    XML.WriteToFile(savePath, settings);
-            //}
-            //catch(PCAxis.Menu.Exceptions.InvalidMenuFromXMLException)
-            //{
-            //    Master.ShowInfoDialog("PxWebAdminToolsXMLGeneratorLanguageError", "PxWebAdminToolsXMLGeneratorLanguageErrorInfo");
-            //}
-            //Master.ShowInfoDialog("PxWebAdminToolsXMLGeneratorSelectLicense", preferredLanguage);
         }
     }
 }

--- a/PXWeb/Admin/Tools-XMLGenerator.aspx.designer.cs
+++ b/PXWeb/Admin/Tools-XMLGenerator.aspx.designer.cs
@@ -258,6 +258,33 @@ namespace PXWeb.Admin
         protected global::System.Web.UI.WebControls.ImageButton imgSelectPublisher;
 
         /// <summary>
+        /// lblStatus control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblStatus;
+
+        /// <summary>
+        /// lblStatusValue control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblStatusValue;
+
+        /// <summary>
+        /// imgStatus control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.ImageButton imgStatus;
+
+        /// <summary>
         /// btnGenerateXML control.
         /// </summary>
         /// <remarks>

--- a/PXWeb/Code/BackgroundWorker/PxWebBackgroundWorker.cs
+++ b/PXWeb/Code/BackgroundWorker/PxWebBackgroundWorker.cs
@@ -313,19 +313,20 @@ namespace PXWeb.BackgroundWorker
             {
                 languages.Add(firstTwo(ls.Name));
             }
-            string themeMapping = HttpContext.Current.Server.MapPath("~/TMapping.json");
+            string themeMapping = System.Web.Hosting.HostingEnvironment.MapPath("~/TMapping.json");
             string dbType = dcat.DatabaseType;
             string dbid;
             IFetcher fetcher;
+            string databasepath = GetDatabasePath();
 
-            string savePath = HttpContext.Current.Server.MapPath(PXWeb.Settings.Current.General.Paths.PxDatabasesPath + dcat.Database + "/dcat-ap.xml");
+            string savePath = databasepath + dcat.Database + "/dcat-ap.xml";
             switch (dbType)
             {
                 case "PX":
-                    dbid = HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/") + dcat.Database + "/Menu.xml";
-                    string localThemeMapping = HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/") + dcat.Database + "/TMapping.json";
+                    dbid = databasepath + dcat.Database + "/Menu.xml";
+                    string localThemeMapping = databasepath + dcat.Database + "/TMapping.json";
                     if (File.Exists(localThemeMapping)) themeMapping = localThemeMapping;
-                    fetcher = new PXFetcher(HttpContext.Current.Server.MapPath("~/Resources/PX/Databases/"));
+                    fetcher = new PXFetcher(databasepath);
                     break;
                 case "CNMM":
                     dbid = dcat.Database;

--- a/PXWeb/Code/BackgroundWorker/PxWebBackgroundWorker.cs
+++ b/PXWeb/Code/BackgroundWorker/PxWebBackgroundWorker.cs
@@ -211,7 +211,7 @@ namespace PXWeb.BackgroundWorker
         {
             try
             {
-                _activity = "Checking search indexes";
+                _activity = "Checking databases";
 
                 string path = GetDatabasePath();
 
@@ -302,6 +302,7 @@ namespace PXWeb.BackgroundWorker
         /// <param name="database"></param>
         private static void CreateDcatFile(string database)
         {
+            _activity = "Creating dcat file for the " + database + " database";
             PXWeb.DatabaseSettings db = (PXWeb.DatabaseSettings)PXWeb.Settings.Current.GetDatabase(database);
             PXWeb.DcatSettings dcat = (PXWeb.DcatSettings)db.Dcat;
 

--- a/PXWeb/Code/Settings/DatabaseSettings.cs
+++ b/PXWeb/Code/Settings/DatabaseSettings.cs
@@ -43,6 +43,11 @@ namespace PXWeb
         private SearchIndexSettings _searchIndexSettings;
 
         /// <summary>
+        /// Dcat settings
+        /// </summary>
+        private DcatSettings _dcatSettings;
+
+        /// <summary>
         /// The protection settings
         /// </summary>
         private ProtectionSettings _protection;
@@ -129,6 +134,10 @@ namespace PXWeb
                 node = SettingsHelper.GetNode(settingsNode, xpath);
                 _searchIndexSettings = new SearchIndexSettings(node);
 
+                xpath = "/settings/dcat";
+                node = SettingsHelper.GetNode(settingsNode, xpath);
+                _dcatSettings = new DcatSettings(node);
+
                 xpath = "/settings/protection";
                 node = SettingsHelper.GetNode(settingsNode, xpath);
                 _protection = new ProtectionSettings(node);
@@ -183,6 +192,10 @@ namespace PXWeb
             xpath = "/settings/searchIndex";
             node = SettingsHelper.GetNode(settingsNode, xpath);
             _searchIndexSettings.Save(node);
+
+            xpath = "/settings/dcat";
+            node = SettingsHelper.GetNode(settingsNode, xpath);
+            _dcatSettings.Save(node);
 
             xpath = "/settings/protection";
             node = SettingsHelper.GetNode(settingsNode, xpath);
@@ -247,6 +260,11 @@ namespace PXWeb
         public ISearchIndexSettings SearchIndex
         {
             get { return _searchIndexSettings; }
+        }
+
+        public IDcatSettings Dcat
+        {
+            get { return _dcatSettings; }
         }
 
         public IProtection Protection

--- a/PXWeb/Code/Settings/DcatSettings.cs
+++ b/PXWeb/Code/Settings/DcatSettings.cs
@@ -98,6 +98,12 @@ namespace PXWeb
 
             xpath = "./License";
             SettingsHelper.SetSettingValue(xpath, chartsNode, License);
+
+            xpath = "./DcatFileStatus";
+            SettingsHelper.SetSettingValue(xpath, chartsNode, FileStatus.ToString());
+
+            xpath = "./FileUpdated";
+            SettingsHelper.SetSettingValue(xpath, chartsNode, FileUpdated);
         }
 
         public string BaseURI { get; set; }
@@ -109,6 +115,8 @@ namespace PXWeb
         public string Database { get; set; }
         public string DatabaseType { get; set; }
         public string License { get; set; }
+        public DcatStatusType FileStatus { get; set; }
+        public string FileUpdated { get; set; }
         #endregion
     }
 }

--- a/PXWeb/Code/Settings/DcatSettings.cs
+++ b/PXWeb/Code/Settings/DcatSettings.cs
@@ -29,81 +29,85 @@ namespace PXWeb
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="chartsNode">XML-node for the Dcat settings</param>
-        public DcatSettings(XmlNode chartsNode)
+        /// <param name="node">XML-node for the Dcat settings</param>
+        public DcatSettings(XmlNode node)
         {
             string xpath;
-            XmlNode node;
 
             xpath = "./BaseURI";
-            BaseURI = SettingsHelper.GetSettingValue(xpath, chartsNode, "https://baseURI.com/");
+            BaseURI = SettingsHelper.GetSettingValue(xpath, node, "https://baseURI.com/");
 
             xpath = "./BaseApiUrl";
-            BaseApiUrl = SettingsHelper.GetSettingValue(xpath, chartsNode, "https://baseAPI.com/");
+            BaseApiUrl = SettingsHelper.GetSettingValue(xpath, node, "https://baseAPI.com/");
             
             xpath = "./LandingPageUrl";
-            LandingPageUrl = SettingsHelper.GetSettingValue(xpath, chartsNode, "https://baseLandingPage.com/");
+            LandingPageUrl = SettingsHelper.GetSettingValue(xpath, node, "https://baseLandingPage.com/");
             
             xpath = "./CatalogTitle";
-            CatalogTitle = SettingsHelper.GetSettingValue(xpath, chartsNode, "Catalog title");
+            CatalogTitle = SettingsHelper.GetSettingValue(xpath, node, "Catalog title");
             
             xpath = "./CatalogDescription";
-            CatalogDescription = SettingsHelper.GetSettingValue(xpath, chartsNode, "Catalog description");
+            CatalogDescription = SettingsHelper.GetSettingValue(xpath, node, "Catalog description");
             
             xpath = "./Publisher";
-            Publisher = SettingsHelper.GetSettingValue(xpath, chartsNode, "SCB");
+            Publisher = SettingsHelper.GetSettingValue(xpath, node, "SCB");
             
             xpath = "./Database";
-            Database = SettingsHelper.GetSettingValue(xpath, chartsNode, "Example");
+            Database = SettingsHelper.GetSettingValue(xpath, node, "Example");
             
             xpath = "./DatabaseType";
-            DatabaseType = SettingsHelper.GetSettingValue(xpath, chartsNode, "PX");
+            DatabaseType = SettingsHelper.GetSettingValue(xpath, node, "PX");
             
             xpath = "./License";
-            License = SettingsHelper.GetSettingValue(xpath, chartsNode, "http://creativecommons.org/publicdomain/zero/1.0/");
+            License = SettingsHelper.GetSettingValue(xpath, node, "http://creativecommons.org/publicdomain/zero/1.0/");
+
+            xpath = "./DcatFileStatus";
+            FileStatus = SettingsHelper.GetSettingValue(xpath, node, DcatStatusType.NotCreated);
+
+            xpath = "./FileUpdated";
+            FileUpdated = SettingsHelper.GetSettingValue(xpath, node, "");
         }
 
         /// <summary>
         /// Save Dcat settings to the settings file
         /// </summary>
         /// <param name="generalNode">XML-node for the Dcat settings</param>
-        public void Save(XmlNode chartsNode)
+        public void Save(XmlNode node)
         {
             string xpath;
-            XmlNode node;
 
             xpath = "./BaseURI";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, BaseURI);
+            SettingsHelper.SetSettingValue(xpath, node, BaseURI);
 
             xpath = "./BaseApiUrl";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, BaseApiUrl);
+            SettingsHelper.SetSettingValue(xpath, node, BaseApiUrl);
 
             xpath = "./LandingPageUrl";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, LandingPageUrl);
+            SettingsHelper.SetSettingValue(xpath, node, LandingPageUrl);
 
             xpath = "./CatalogTitle";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, CatalogTitle);
+            SettingsHelper.SetSettingValue(xpath, node, CatalogTitle);
 
             xpath = "./CatalogDescription";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, CatalogDescription);
+            SettingsHelper.SetSettingValue(xpath, node, CatalogDescription);
 
             xpath = "./Publisher";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, Publisher);
+            SettingsHelper.SetSettingValue(xpath, node, Publisher);
 
             xpath = "./Database";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, Database);
+            SettingsHelper.SetSettingValue(xpath, node, Database);
 
             xpath = "./DatabaseType";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, DatabaseType);
+            SettingsHelper.SetSettingValue(xpath, node, DatabaseType);
 
             xpath = "./License";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, License);
+            SettingsHelper.SetSettingValue(xpath, node, License);
 
             xpath = "./DcatFileStatus";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, FileStatus.ToString());
+            SettingsHelper.SetSettingValue(xpath, node, FileStatus.ToString());
 
             xpath = "./FileUpdated";
-            SettingsHelper.SetSettingValue(xpath, chartsNode, FileUpdated);
+            SettingsHelper.SetSettingValue(xpath, node, FileUpdated);
         }
 
         public string BaseURI { get; set; }

--- a/PXWeb/Code/Settings/Enums/DcatStatusType.cs
+++ b/PXWeb/Code/Settings/Enums/DcatStatusType.cs
@@ -1,0 +1,25 @@
+﻿namespace PXWeb
+{
+    /// <summary>
+    /// Describes status of dcat file creation
+    /// </summary>
+    public enum DcatStatusType
+    {
+        /// <summary>
+        /// The dcat file has not been created
+        /// </summary>
+        NotCreated,
+        /// <summary>
+        /// The file has been created
+        /// </summary>
+        Created,
+        /// <summary>
+        /// The file is being created right now
+        /// </summary>
+        Creating,
+        /// <summary>
+        /// The file is waiting to be (re)created
+        /// </summary>
+        WaitingCreate
+    }
+}

--- a/PXWeb/Code/Settings/Interfaces/IDatabaseSettings.cs
+++ b/PXWeb/Code/Settings/Interfaces/IDatabaseSettings.cs
@@ -19,6 +19,11 @@ namespace PXWeb
         ISearchIndexSettings SearchIndex { get; }
 
         /// <summary>
+        /// Dcat settings
+        /// </summary>
+        IDcatSettings Dcat { get; }
+
+        /// <summary>
         /// The database protection
         /// </summary>
         IProtection Protection { get; }

--- a/PXWeb/Code/Settings/Interfaces/IDcatSettings.cs
+++ b/PXWeb/Code/Settings/Interfaces/IDcatSettings.cs
@@ -57,5 +57,9 @@ namespace PXWeb
         /// License for referencing in each dataset
         /// </summary>
         string License { get; }
+
+        string FileUpdated { get; }
+
+        DcatStatusType FileStatus { get; }
     }
 }

--- a/PXWeb/Code/Settings/SettingsHelper.cs
+++ b/PXWeb/Code/Settings/SettingsHelper.cs
@@ -766,6 +766,44 @@ namespace PXWeb
         }
 
         /// <summary>
+        /// Selects single node from passed XmlNode and returns corresponding DcatStatusType, if the node is not found the given defaultvalue is returned
+        /// </summary>
+        /// <param name="xpath">Expression to select node containing setting value</param>
+        /// <param name="selectionNode">Node to apply xpath expression on</param>
+        /// <param name="defaultValue">Value to return if node is not found or not possible to parse as a DcatStatusType</param>
+        public static DcatStatusType GetSettingValue(string xpath, XmlNode selectionNode, DcatStatusType defaultValue)
+        {
+            DcatStatusType returnValue = defaultValue;
+            XmlNode node = null;
+            if (selectionNode != null)
+            {
+                node = selectionNode.SelectSingleNode(xpath);
+            }
+            if (node != null)
+            {
+                switch (node.InnerText)
+                {
+                    case "Created":
+                        returnValue = DcatStatusType.Created;
+                        break;
+                    case "Creating":
+                        returnValue = DcatStatusType.Creating;
+                        break;
+                    case "NotCreated":
+                        returnValue = DcatStatusType.NotCreated;
+                        break;
+                    case "WaitingCreate":
+                        returnValue = DcatStatusType.WaitingCreate;
+                        break;
+                    default:
+                        returnValue = DcatStatusType.NotCreated;
+                        break;
+                }
+            }
+            return returnValue;
+        }
+
+        /// <summary>
         /// Selects single node from passed XmlNode and returns corresponding SavedQueryStorageType, if the node is not found the given defaultvalue is returned
         /// </summary>
         /// <param name="xpath">Expression to select node containing setting value</param>

--- a/PXWeb/PXWeb.csproj
+++ b/PXWeb/PXWeb.csproj
@@ -723,6 +723,7 @@
     <Compile Include="Code\Settings\DatabaseInfo.cs" />
     <Compile Include="Code\Settings\DatabaseSettings.cs" />
     <Compile Include="Code\Settings\DatabasesSettings.cs" />
+    <Compile Include="Code\Settings\Enums\DcatStatusType.cs" />
     <Compile Include="Code\Settings\Enums\MainHeaderForTablesType.cs" />
     <Compile Include="Code\Settings\Enums\SearchIndexStatusType.cs" />
     <Compile Include="Code\Settings\Enums\MenuModeType.cs" />

--- a/PXWeb/Resources/Languages/pxlang.sv.xml
+++ b/PXWeb/Resources/Languages/pxlang.sv.xml
@@ -682,7 +682,7 @@
   <sentence name="PxWebAdminMenuToolsLanguageManager" value="Språkhanteraren" />
   <sentence name="PxWebAdminMenuToolsReset" value="Nollställ" />
   <sentence name="PxWebAdminMenuToolsChangePassword" value="Byt lösenord" />
-  <sentence name="PxWebAdminMenuToolsXMLGenerator" value="Generera XML"/>
+  <sentence name="PxWebAdminMenuToolsXMLGenerator" value="Dcat"/>
   <sentence name="PxWebAdminMenuFeatures" value="Funktioner" />
   <sentence name="PxWebAdminMenuFeaturesGeneral" value="Generellt" />
   <sentence name="PxWebAdminMenuFeaturesCharts" value="Diagram" />
@@ -986,6 +986,8 @@
  <sentence name="PxWebAdminToolsXMLGeneratorSelectLandingPageURLInfo" value="Ingångssida till webbsida som ger tillgång till datamängden eller dess distributioner och/eller ytterligare information"/>
  <sentence name="PxWebAdminToolsXMLGeneratorSelectPublisher" value="Utgivare"/>
  <sentence name="PxWebAdminToolsXMLGeneratorSelectPublisherInfo" value="Utgivare av datan"/>
+ <sentence name="PxWebAdminToolsXMLGeneratorStatus" value="Status"/>
+ <sentence name="PxWebAdminToolsXMLGeneratorStatusInfo" value="Status för generering av Dcat-XML-fil för vald databas"/>
  <sentence name="PxWebAdminToolsXMLGeneratorLanguageError" value="Fel"/>
  <sentence name="PxWebAdminToolsXMLGeneratorLanguageErrorInfo" value="Det valda språket finns inte tillgängligt för den valda databasen"/>
  <sentence name="PxWebAdminFeaturesGeneralFeature" value="Funktion" />

--- a/PXWeb/Resources/Languages/pxlang.xml
+++ b/PXWeb/Resources/Languages/pxlang.xml
@@ -857,7 +857,7 @@
 
 
   <sentence name="PxWebAdminMenuToolsLanguageManager" value="Language Manager"/>
-  <sentence name="PxWebAdminMenuToolsXMLGenerator" value="Generate XML"/>
+  <sentence name="PxWebAdminMenuToolsXMLGenerator" value="Dcat"/>
 	<sentence name="PxWebAdminToolsXMLGeneratorLanguages" value="Select wanted languages"/>
 	 <sentence name="PxWebAdminMenuToolsReset" value="Reset"/>
 	 <sentence name="PxWebAdminMenuToolsChangePassword" value="Change password"/>
@@ -1167,6 +1167,8 @@
 	<sentence name="PxWebAdminToolsXMLGeneratorSelectLandingPageURLInfo" value="Base URL for the datasets"/>
 	<sentence name="PxWebAdminToolsXMLGeneratorSelectPublisher" value="Publisher"/>
 	<sentence name="PxWebAdminToolsXMLGeneratorSelectPublisherInfo" value="Publisher of the data"/>
+	<sentence name="PxWebAdminToolsXMLGeneratorStatus" value="Status"/>
+	<sentence name="PxWebAdminToolsXMLGeneratorStatusInfo" value="Status for generation of Dcat-XML file for the chosen database"/>
 	<sentence name="PxWebAdminToolsXMLGeneratorLanguageError" value="Error"/>
 	<sentence name="PxWebAdminToolsXMLGeneratorLanguageErrorInfo" value="Chosen preferred language not available for chosen database"/>
 	<sentence name="PxWebAdminToolsGenerateDbSelectDb" value="Generate PX database"/>

--- a/PXWeb/Resources/PX/Databases/Example/database.config
+++ b/PXWeb/Resources/PX/Databases/Example/database.config
@@ -3,7 +3,7 @@
   <homePages />
   <searchIndex>
     <status>Indexed</status>
-    <indexUpdated>20210323 09:47</indexUpdated>
+    <indexUpdated>20230404 08:53</indexUpdated>
     <updateMethod>
     </updateMethod>
   </searchIndex>
@@ -19,4 +19,18 @@
     <metaLinkMethod>
     </metaLinkMethod>
   </metadata>
+  <dcat>
+    <BaseURI>https://baseURI.com/</BaseURI>
+    <BaseApiUrl>https://baseAPI.com/</BaseApiUrl>
+    <LandingPageUrl>https://baseLandingPage.com/</LandingPageUrl>
+    <CatalogTitle>Catalog title</CatalogTitle>
+    <CatalogDescription>Catalog description</CatalogDescription>
+    <Publisher>SCB - test</Publisher>
+    <Database>Example</Database>
+    <DatabaseType>PX</DatabaseType>
+    <License>http://creativecommons.org/publicdomain/zero/1.0/</License>
+    <DcatFileStatus>NotCreated</DcatFileStatus>
+    <FileUpdated>
+    </FileUpdated>
+  </dcat>
 </settings>


### PR DESCRIPTION
* Dcat tool can now be run as a background process by the BackgroundWorker
* Dcat settings are stored separately for each database in the corresponding database.config file
* The current status of creating the Dcat file is now shown on the interface