### PR TITLE
Api-V2 url links

### DIFF
--- a/PCAxis.Web.Controls/Query/TableQuery.ascx
+++ b/PCAxis.Web.Controls/Query/TableQuery.ascx
@@ -22,6 +22,24 @@
                 </div>
             </div>
         </asp:Panel>
+        <asp:Panel ID="pnlQueryInformationV2" CssClass="tablequery_informationpanel" runat="server">
+            <asp:Label ID="lblV2text" runat="server" Text="" CssClass="tablequery_V2caption">Api-V2:</asp:Label>
+            <asp:Label ID="lblInformationTextV2" runat="server" Text="" CssClass="tablequery_informationtext"></asp:Label>
+            <asp:Label ID="lblUrlV2" runat="server" Text="" AssociatedControlID="txtUrl" CssClass="tablequery_urlcaption"></asp:Label>
+            <asp:TextBox ID="txtUrlV2" runat="server" ReadOnly="true" CssClass="tablequery_url"></asp:TextBox>
+            <asp:Button ID="btnCopyUrlV2" text="<%$ PxString: CtrlTableQueryCopy %>" runat="server" ClientIDMode="static" CssClass="pxweb-btn pxweb-buttons" OnClientClick="CopyQuery();return false" CausesValidation="false"></asp:Button>
+        </asp:Panel>
     </div>
 </div>
 </asp:panel>
+<script type="text/javascript">
+    function CopyQuery() {
+        var copyText = document.getElementById('<%=txtUrlV2.ClientID %>')
+        copyText.focus();
+        copyText.select(); // for mark as copied
+
+        // Copy the text inside the text field
+        navigator.clipboard.writeText("<%=txtUrlV2.Text%>");
+        return false;
+    }
+</script>

--- a/PCAxis.Web.Controls/Query/TableQuery.vb
+++ b/PCAxis.Web.Controls/Query/TableQuery.vb
@@ -23,13 +23,35 @@ Partial Public Class TableQuery
     ''' <value></value>
     ''' <returns></returns>
     ''' <remarks></remarks>
-    <PropertyPersistState(Core.Enums.PersistStateType.PerControlAndPage)> _
+    <PropertyPersistState(Core.Enums.PersistStateType.PerControlAndPage)>
     Public Property URLRoot() As String
         Get
             Return _urlRoot
         End Get
         Set(ByVal value As String)
             _urlRoot = value
+        End Set
+    End Property
+
+    Private _urlRootV2 As String
+    <PropertyPersistState(Core.Enums.PersistStateType.PerControlAndPage)>
+    Public Property URLRootV2() As String
+        Get
+            Return _urlRootV2
+        End Get
+        Set(ByVal value As String)
+            _urlRootV2 = value
+        End Set
+    End Property
+
+    Private _enableApiV2QueryLink As Boolean
+    <PropertyPersistState(Core.Enums.PersistStateType.PerControlAndPage)>
+    Public Property EnableApiV2QueryLink() As Boolean
+        Get
+            Return _enableApiV2QueryLink
+        End Get
+        Set(ByVal value As Boolean)
+            _enableApiV2QueryLink = value
         End Set
     End Property
 

--- a/PCAxis.Web.Controls/Query/TableQueryCodebehind.vb
+++ b/PCAxis.Web.Controls/Query/TableQueryCodebehind.vb
@@ -21,23 +21,30 @@ Public Class TableQueryCodebehind
 
 #Region "fields"
     Protected pnlQueryInformation As Panel
+    Protected pnlQueryInformationV2 As Panel
     Protected lblInformationText As Label
+    Protected lblInformationTextV2 As Label
     Protected lblUrl As Label
+    Protected lblUrlV2 As Label
     Protected txtUrl As TextBox
+    Protected txtUrlV2 As TextBox
     Protected lblQuery As Label
     Protected txtQuery As TextBox
     Protected lnkMoreInfo As HyperLink
     Protected WithEvents btnSaveQuery As Button
     Protected lblTableQueryInformation As Label
+    Protected btnCopyUrlV2 As Button
 #End Region
 
 #Region "Localized strings"
     Private Const LOC_TABLEQUERY_SHOW_INFORMATION As String = "CtrlTableQueryShowInformation"
     Private Const LOC_TABLEQUERY_INFORMATION_TEXT As String = "CtrlTableQueryInformationText"
+    Private Const LOC_TABLEQUERY_V2_INFORMATION_TEXT As String = "CtrlTableQueryV2InformationText"
     Private Const LOC_TABLEQUERY_URL_CAPTION As String = "CtrlTableQueryUrlCaption"
     Private Const LOC_TABLEQUERY_QUERY_CAPTION As String = "CtrlTableQueryQueryCaption"
     Private Const LOC_TABLEQUERY_MORE_INFORMATION As String = "CtrlTableQueryMoreInformation"
     Private Const LOC_TABLEQUERY_SAVE_QUERY As String = "CtrlTableQuerySaveQuery"
+    Private Const LOC_TABLEQUERY_COPY As String = "CtrlTableQueryCopy"
 #End Region
 
 #Region "Events"
@@ -47,10 +54,12 @@ Public Class TableQueryCodebehind
             If VerifyDatabase() Then
                 Me.Visible = True
                 ShowApiURL()
+                ShowApiV2URL()
                 ShowApiQuery()
                 ShowMoreInfoLink()
                 Localize()
                 btnSaveQuery.Visible = Marker.ShowSaveApiQueryButton
+                pnlQueryInformationV2.Visible = Marker.EnableApiV2QueryLink
             Else
                 Me.Visible = False
             End If
@@ -61,6 +70,7 @@ Public Class TableQueryCodebehind
         If Me.Visible Then
             Localize()
             ShowApiURL()
+            ShowApiV2URL()
         End If
     End Sub
 
@@ -144,12 +154,15 @@ Public Class TableQueryCodebehind
     ''' <remarks></remarks>
     Private Sub Localize()
         lblInformationText.Text = GetLocalizedString(LOC_TABLEQUERY_INFORMATION_TEXT)
+        lblInformationTextV2.Text = GetLocalizedString(LOC_TABLEQUERY_V2_INFORMATION_TEXT)
         lblUrl.Text = GetLocalizedString(LOC_TABLEQUERY_URL_CAPTION)
+        lblUrlV2.Text = GetLocalizedString(LOC_TABLEQUERY_URL_CAPTION)
         lblQuery.Text = GetLocalizedString(LOC_TABLEQUERY_QUERY_CAPTION)
         
         lnkMoreInfo.Text = String.Format("<span class=link-text>{0}</span>", Server.HtmlEncode(GetLocalizedString(LOC_TABLEQUERY_MORE_INFORMATION)))
         btnSaveQuery.Text = GetLocalizedString(LOC_TABLEQUERY_SAVE_QUERY)
         lblTableQueryInformation.Text = GetLocalizedString(LOC_TABLEQUERY_SHOW_INFORMATION)
+        btnCopyUrlV2.Text = GetLocalizedString(LOC_TABLEQUERY_COPY)
     End Sub
 
     ''' <summary>
@@ -233,6 +246,76 @@ Public Class TableQueryCodebehind
 
         txtUrl.Text = sb.ToString()
     End Sub
+
+    ''' <summary>
+    ''' Show the API-V2 URL
+    ''' </summary>
+    ''' <remarks></remarks>
+    Private Sub ShowApiV2URL()
+        Dim sb As New System.Text.StringBuilder()
+        If Marker.DatabaseType = PCAxis.Web.Core.Enums.DatabaseType.PX Then
+            txtUrlV2.Text = "-"
+            Return
+        End If
+
+        Dim route As String
+        If Not Marker.URLRootV2 Is Nothing Then
+            route = Marker.URLRootV2.Replace("\", "/")
+            sb.Append(route)
+            If Not route.EndsWith("/") Then
+                sb.Append("/")
+            End If
+        End If
+
+        sb.Append("tables/")
+
+        Dim builder As IPXModelBuilder = PaxiomManager.PaxiomModelBuilder()
+        Dim model As PXModel = PaxiomManager.PaxiomModel
+        Dim tableId As String = model.Meta.TableID
+        sb.Append(tableId)
+
+        sb.Append("/data")
+
+        Dim lang As String = LocalizationManager.CurrentCulture.Name
+        lang = Util.GetLanguageForNet3_5(lang)
+        sb.Append("?lang=")
+        sb.Append(lang)
+
+
+        For Each var In model.Meta.Variables
+            Dim values As String = GetValuesString(var.Values)
+            'If var.CurrentValueSet IsNot Nothing Then
+            '    sb.Append(String.Format("&codelist[{0}]={1}", var.Code, var.CurrentValueSet.ID))
+            'End If
+            'If var.CurrentGrouping IsNot Nothing Then
+            '    sb.Append(String.Format("&outputValues[{0}]={1}", var.Code, "aggregated"))
+            'End If
+            sb.Append(String.Format("&valueCodes[{0}]={1}", var.Code, values))
+        Next
+
+        For Each var In PaxiomManager.QueryModel.Query
+            Dim filter As String = var.Selection.Filter
+            Dim prefix As String = filter.Split(":"c).First()
+            Dim suffix As String = filter.Split(":"c).Last()
+            If prefix.Equals("vs") Or prefix.Equals("agg") Then
+                sb.Append(String.Format("&codelist[{0}]={1}_{2}", var.Code, prefix, suffix))
+            End If
+            If prefix.Equals("agg") Then
+                sb.Append(String.Format("&outputValues[{0}]={1}", var.Code, "aggregated"))
+            End If
+        Next
+
+        txtUrlV2.Text = sb.ToString()
+    End Sub
+    Private Function GetValuesString(var As Values) As String
+        Dim valuesSB As New System.Text.StringBuilder()
+        For Each val As Value In var
+            valuesSB.Append(val.Code)
+            valuesSB.Append(",")
+        Next
+        valuesSB.Remove(valuesSB.Length - 1, 1)
+        Return valuesSB.ToString()
+    End Function
 
     Private Function GetAppPath() As String
         Dim appPath As String = String.Empty

--- a/PCAxis.Web.Controls/Query/TableQueryCodebehind.vb
+++ b/PCAxis.Web.Controls/Query/TableQueryCodebehind.vb
@@ -272,6 +272,12 @@ Public Class TableQueryCodebehind
         Dim builder As IPXModelBuilder = PaxiomManager.PaxiomModelBuilder()
         Dim model As PXModel = PaxiomManager.PaxiomModel
         Dim tableId As String = model.Meta.TableID
+
+        'If PX file the Matrix should be used as tabled identifier
+        If TypeOf PaxiomManager.PaxiomModelBuilder Is PXFileBuilder Then
+            tableId = model.Meta.Matrix
+        End If
+
         sb.Append(tableId)
 
         sb.Append("/data")

--- a/PCAxis.Web.Controls/Query/TableQueryCodebehind.vb
+++ b/PCAxis.Web.Controls/Query/TableQueryCodebehind.vb
@@ -253,11 +253,6 @@ Public Class TableQueryCodebehind
     ''' <remarks></remarks>
     Private Sub ShowApiV2URL()
         Dim sb As New System.Text.StringBuilder()
-        If Marker.DatabaseType = PCAxis.Web.Core.Enums.DatabaseType.PX Then
-            txtUrlV2.Text = "-"
-            Return
-        End If
-
         Dim route As String
         If Not Marker.URLRootV2 Is Nothing Then
             route = Marker.URLRootV2.Replace("\", "/")
@@ -274,7 +269,7 @@ Public Class TableQueryCodebehind
         Dim tableId As String = model.Meta.TableID
 
         'If PX file the Matrix should be used as tabled identifier
-        If TypeOf PaxiomManager.PaxiomModelBuilder Is PXFileBuilder Then
+        If Marker.DatabaseType = PCAxis.Web.Core.Enums.DatabaseType.PX Then
             tableId = model.Meta.Matrix
         End If
 

--- a/PXWeb/Admin/Features-Api-General.aspx
+++ b/PXWeb/Admin/Features-Api-General.aspx
@@ -41,6 +41,24 @@
     </div>
 
     <div class="setting-field">
+        <asp:Label ID="lblEnableApiV2QueryLink" runat="server" Text="<%$ PxString: PxWebAdminFeaturesApiGeneralEnableApiV2QueryLink %>"></asp:Label>
+        <asp:DropDownList ID="cboEnableApiV2QueryLink" runat="server">
+            <asp:ListItem Value="True" Text="<%$ PxString: PxWebAdminYes %>"></asp:ListItem>
+            <asp:ListItem Value="False" Text="<%$ PxString: PxWebAdminNo %>"></asp:ListItem>
+        </asp:DropDownList>
+        &nbsp;<asp:ImageButton ID="imgEnableApiV2QueryLink" runat="server" onclick="EnableApiV2QueryLinkInfo" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />
+    </div>
+
+    <div class="setting-field">
+        <asp:Label ID="lblUrlRootV2" runat="server" Text="<%$ PxString: PxWebAdminFeaturesApiGeneralUrlRootV2 %>"></asp:Label>
+        <asp:TextBox ID="txtUrlRootV2" runat="server"></asp:TextBox>
+        <asp:ImageButton ID="imgUrlRootV2" runat="server" onclick="UrlRootInfoV2" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />
+        <asp:CustomValidator ID="validatorUrlRootV2" runat="server" 
+        ControlToValidate="txtUrlRootV2" OnServerValidate="ValidateUrlRoot"
+        ErrorMessage="*" ValidateEmptyText="False" CssClass="setting-field-validator" ></asp:CustomValidator>
+    </div>
+
+    <div class="setting-field">
         <asp:Label ID="lblMaxValuesReturned" runat="server" Text="<%$ PxString: PxWebAdminFeaturesApiGeneralMaxValuesReturned %>"></asp:Label>
         <asp:TextBox ID="txtMaxValuesReturned" runat="server" CssClass="smallinput" MaxLength="10" Width="50px"></asp:TextBox>
         <asp:ImageButton ID="imgMaxValuesReturned" runat="server" onclick="MaxValuesReturnedInfo" Height="15px" Width="15px" ImageUrl="<%$ PxImage: questionmark.gif %>" />

--- a/PXWeb/Admin/Features-Api-General.aspx.cs
+++ b/PXWeb/Admin/Features-Api-General.aspx.cs
@@ -48,6 +48,7 @@ namespace PXWeb.Admin
             txtFetchCellLimit.Text = PXWeb.Settings.Current.Features.Api.FetchCellLimit.ToString();
             cboEnableCORS.SelectedValue = PXWeb.Settings.Current.Features.Api.EnableCORS.ToString();
             cboEnableCache.SelectedValue = PXWeb.Settings.Current.Features.Api.EnableCache.ToString();
+            cboEnableApiV2QueryLink.SelectedValue = PXWeb.Settings.Current.Features.Api.EnableApiV2QueryLink.ToString();
             //txtClearCache.Text = PXWeb.Settings.Current.Features.Api.ClearCache;
             cboShowQueryInformation.SelectedValue = PXWeb.Settings.Current.Features.Api.ShowQueryInformation.ToString();
             cboDefaultExampleResponseFormat.SelectedValue = PXWeb.Settings.Current.Features.Api.DefaultExampleResponseFormat;
@@ -55,6 +56,7 @@ namespace PXWeb.Admin
             txtSaveApiQueryText.Text = PXWeb.Settings.Current.Features.Api.SaveApiQueryText.ToString();
             ShowHideTextboxForQueryPrefix();
             txtUrlRoot.Text = PXWeb.Settings.Current.Features.Api.UrlRoot;
+            txtUrlRootV2.Text = PXWeb.Settings.Current.Features.Api.UrlRootV2;
         }
 
         /// <summary>
@@ -224,6 +226,8 @@ namespace PXWeb.Admin
                         api.SaveApiQueryText = txtSaveApiQueryText.Text;
 
                         api.UrlRoot = txtUrlRoot.Text;
+                        api.UrlRootV2 = txtUrlRootV2.Text;
+                        api.EnableApiV2QueryLink = bool.Parse(cboEnableApiV2QueryLink.SelectedValue);
 
                         PXWeb.Settings.Save();
 
@@ -483,6 +487,14 @@ namespace PXWeb.Admin
             Master.ShowInfoDialog("PxWebAdminFeaturesApiGeneralUrlRoot", "PxWebAdminFeaturesApiGeneralUrlRootInfo");
         }
 
+        protected void UrlRootInfoV2(object sender, ImageClickEventArgs e)
+        {
+            Master.ShowInfoDialog("PxWebAdminFeaturesApiGeneralUrlRootV2", "PxWebAdminFeaturesApiGeneralUrlRootInfoV2");
+        }
+        protected void EnableApiV2QueryLinkInfo(object sender, ImageClickEventArgs e)
+        {
+            Master.ShowInfoDialog("PxWebAdminFeaturesApiGeneralEnableApiV2QueryLink", "PxWebAdminFeaturesApiGeneralEnableApiV2QueryLinkInfo");
+        }
         protected void ShowSaveApiQueryButtonInfo(object sender, ImageClickEventArgs e)
         {
             Master.ShowInfoDialog("PxWebAdminFeaturesApiGeneralShowSaveApiQueryButton", "PxWebAdminFeaturesApiGeneralShowSaveApiQueryButtonInfo");

--- a/PXWeb/Admin/Features-Api-General.aspx.designer.cs
+++ b/PXWeb/Admin/Features-Api-General.aspx.designer.cs
@@ -7,11 +7,13 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PXWeb.Admin {
-    
-    
-    public partial class Features_Api_General {
-        
+namespace PXWeb.Admin
+{
+
+
+    public partial class Features_Api_General
+    {
+
         /// <summary>
         /// lblApiSetting control.
         /// </summary>
@@ -20,7 +22,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblApiSetting;
-        
+
         /// <summary>
         /// lblPxDatabases control.
         /// </summary>
@@ -29,7 +31,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblPxDatabases;
-        
+
         /// <summary>
         /// imgPxDatabases control.
         /// </summary>
@@ -38,7 +40,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgPxDatabases;
-        
+
         /// <summary>
         /// tblPxDatabases control.
         /// </summary>
@@ -47,7 +49,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Table tblPxDatabases;
-        
+
         /// <summary>
         /// lblCnmmDatabases control.
         /// </summary>
@@ -56,7 +58,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblCnmmDatabases;
-        
+
         /// <summary>
         /// imgCnmmDatabases control.
         /// </summary>
@@ -65,7 +67,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgCnmmDatabases;
-        
+
         /// <summary>
         /// tblCnmmDatabases control.
         /// </summary>
@@ -74,7 +76,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Table tblCnmmDatabases;
-        
+
         /// <summary>
         /// lblRoutePrefix control.
         /// </summary>
@@ -83,7 +85,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblRoutePrefix;
-        
+
         /// <summary>
         /// txtRoutePrefix control.
         /// </summary>
@@ -92,7 +94,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtRoutePrefix;
-        
+
         /// <summary>
         /// imgRoutePrefix control.
         /// </summary>
@@ -101,7 +103,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgRoutePrefix;
-        
+
         /// <summary>
         /// validatorRoutePrefix control.
         /// </summary>
@@ -110,7 +112,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorRoutePrefix;
-        
+
         /// <summary>
         /// lblUrlRoot control.
         /// </summary>
@@ -119,7 +121,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblUrlRoot;
-        
+
         /// <summary>
         /// txtUrlRoot control.
         /// </summary>
@@ -128,7 +130,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtUrlRoot;
-        
+
         /// <summary>
         /// imgUrlRoot control.
         /// </summary>
@@ -137,7 +139,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgUrlRoot;
-        
+
         /// <summary>
         /// validatorUrlRoot control.
         /// </summary>
@@ -146,7 +148,70 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorUrlRoot;
-        
+
+        /// <summary>
+        /// lblEnableApiV2QueryLink control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblEnableApiV2QueryLink;
+
+        /// <summary>
+        /// cboEnableApiV2QueryLink control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.DropDownList cboEnableApiV2QueryLink;
+
+        /// <summary>
+        /// imgEnableApiV2QueryLink control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.ImageButton imgEnableApiV2QueryLink;
+
+        /// <summary>
+        /// lblUrlRootV2 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblUrlRootV2;
+
+        /// <summary>
+        /// txtUrlRootV2 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtUrlRootV2;
+
+        /// <summary>
+        /// imgUrlRootV2 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.ImageButton imgUrlRootV2;
+
+        /// <summary>
+        /// validatorUrlRootV2 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CustomValidator validatorUrlRootV2;
+
         /// <summary>
         /// lblMaxValuesReturned control.
         /// </summary>
@@ -155,7 +220,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblMaxValuesReturned;
-        
+
         /// <summary>
         /// txtMaxValuesReturned control.
         /// </summary>
@@ -164,7 +229,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtMaxValuesReturned;
-        
+
         /// <summary>
         /// imgMaxValuesReturned control.
         /// </summary>
@@ -173,7 +238,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgMaxValuesReturned;
-        
+
         /// <summary>
         /// validatorMaxValuesReturned control.
         /// </summary>
@@ -182,7 +247,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorMaxValuesReturned;
-        
+
         /// <summary>
         /// lblFetchCellLimit control.
         /// </summary>
@@ -191,7 +256,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblFetchCellLimit;
-        
+
         /// <summary>
         /// txtFetchCellLimit control.
         /// </summary>
@@ -200,7 +265,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtFetchCellLimit;
-        
+
         /// <summary>
         /// imgFetchCellLimit control.
         /// </summary>
@@ -209,7 +274,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgFetchCellLimit;
-        
+
         /// <summary>
         /// validatorFetchCellLimit control.
         /// </summary>
@@ -218,7 +283,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorFetchCellLimit;
-        
+
         /// <summary>
         /// lblLimiterRequests control.
         /// </summary>
@@ -227,7 +292,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblLimiterRequests;
-        
+
         /// <summary>
         /// txtLimiterRequests control.
         /// </summary>
@@ -236,7 +301,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtLimiterRequests;
-        
+
         /// <summary>
         /// imgLimiterRequests control.
         /// </summary>
@@ -245,7 +310,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgLimiterRequests;
-        
+
         /// <summary>
         /// validatorLimiterRequests control.
         /// </summary>
@@ -254,7 +319,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorLimiterRequests;
-        
+
         /// <summary>
         /// lblLimiterTimespan control.
         /// </summary>
@@ -263,7 +328,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblLimiterTimespan;
-        
+
         /// <summary>
         /// txtLimiterTimespan control.
         /// </summary>
@@ -272,7 +337,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtLimiterTimespan;
-        
+
         /// <summary>
         /// imgLimiterTimespan control.
         /// </summary>
@@ -281,7 +346,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgLimiterTimespan;
-        
+
         /// <summary>
         /// validatorLimiterTimespan control.
         /// </summary>
@@ -290,7 +355,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator validatorLimiterTimespan;
-        
+
         /// <summary>
         /// lblEnableCORS control.
         /// </summary>
@@ -299,7 +364,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblEnableCORS;
-        
+
         /// <summary>
         /// cboEnableCORS control.
         /// </summary>
@@ -308,7 +373,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboEnableCORS;
-        
+
         /// <summary>
         /// imgEnableCORS control.
         /// </summary>
@@ -317,7 +382,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgEnableCORS;
-        
+
         /// <summary>
         /// lblEnableCache control.
         /// </summary>
@@ -326,7 +391,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblEnableCache;
-        
+
         /// <summary>
         /// cboEnableCache control.
         /// </summary>
@@ -335,7 +400,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboEnableCache;
-        
+
         /// <summary>
         /// imgEnableCache control.
         /// </summary>
@@ -344,7 +409,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgEnableCache;
-        
+
         /// <summary>
         /// lblShowQueryInformation control.
         /// </summary>
@@ -353,7 +418,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblShowQueryInformation;
-        
+
         /// <summary>
         /// cboShowQueryInformation control.
         /// </summary>
@@ -362,7 +427,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboShowQueryInformation;
-        
+
         /// <summary>
         /// imgShowQueryInformation control.
         /// </summary>
@@ -371,7 +436,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgShowQueryInformation;
-        
+
         /// <summary>
         /// lblDefaultExampleResponseFormat control.
         /// </summary>
@@ -380,7 +445,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblDefaultExampleResponseFormat;
-        
+
         /// <summary>
         /// cboDefaultExampleResponseFormat control.
         /// </summary>
@@ -389,7 +454,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboDefaultExampleResponseFormat;
-        
+
         /// <summary>
         /// imgDefaultExampleResponseFormat control.
         /// </summary>
@@ -398,7 +463,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgDefaultExampleResponseFormat;
-        
+
         /// <summary>
         /// lblShowSaveApiQueryButton control.
         /// </summary>
@@ -407,7 +472,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblShowSaveApiQueryButton;
-        
+
         /// <summary>
         /// cboShowSaveApiQueryButton control.
         /// </summary>
@@ -416,7 +481,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList cboShowSaveApiQueryButton;
-        
+
         /// <summary>
         /// imgShowSaveApiQueryButton control.
         /// </summary>
@@ -425,7 +490,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgShowSaveApiQueryButton;
-        
+
         /// <summary>
         /// pnlSaveApiQueryText control.
         /// </summary>
@@ -434,7 +499,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Panel pnlSaveApiQueryText;
-        
+
         /// <summary>
         /// lblSaveApiQueryText control.
         /// </summary>
@@ -443,7 +508,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.Label lblSaveApiQueryText;
-        
+
         /// <summary>
         /// txtSaveApiQueryText control.
         /// </summary>
@@ -452,7 +517,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtSaveApiQueryText;
-        
+
         /// <summary>
         /// imgSaveApiQueryText control.
         /// </summary>
@@ -461,7 +526,7 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.ImageButton imgSaveApiQueryText;
-        
+
         /// <summary>
         /// CustomValidator1 control.
         /// </summary>
@@ -470,15 +535,17 @@ namespace PXWeb.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.CustomValidator CustomValidator1;
-        
+
         /// <summary>
         /// Master property.
         /// </summary>
         /// <remarks>
         /// Auto-generated property.
         /// </remarks>
-        public new PXWeb.Admin.Admin Master {
-            get {
+        public new PXWeb.Admin.Admin Master
+        {
+            get
+            {
                 return ((PXWeb.Admin.Admin)(base.Master));
             }
         }

--- a/PXWeb/Code/Settings/ApiSettings.cs
+++ b/PXWeb/Code/Settings/ApiSettings.cs
@@ -26,6 +26,12 @@ namespace PXWeb
             xpath = "./urlRoot";
             UrlRoot = SettingsHelper.GetSettingValue(xpath, apiNode, "");
 
+            xpath = "./urlRootV2";
+            UrlRootV2 = SettingsHelper.GetSettingValue(xpath, apiNode, "");
+
+            xpath = "./enableApiV2QueryLink";
+            EnableApiV2QueryLink = SettingsHelper.GetSettingValue(xpath, apiNode, false);
+
             xpath = "./routePrefix";
             RoutePrefix = SettingsHelper.GetSettingValue(xpath, apiNode, "api/v1/");
 
@@ -75,6 +81,12 @@ namespace PXWeb
             xpath = "./urlRoot";
             SettingsHelper.SetSettingValue(xpath, apiNode, UrlRoot);
 
+            xpath = "./urlRootV2";
+            SettingsHelper.SetSettingValue(xpath, apiNode, UrlRootV2);
+
+            xpath = "./enableApiV2QueryLink";
+            SettingsHelper.SetSettingValue(xpath, apiNode, EnableApiV2QueryLink.ToString());
+
             xpath = "./routePrefix";
             SettingsHelper.SetSettingValue(xpath, apiNode, RoutePrefix);
 
@@ -118,6 +130,8 @@ namespace PXWeb
 
         public int MaxValuesReturned { get; set; }
         public string UrlRoot { get; set; }
+        public string UrlRootV2 { get; set; }
+        public bool EnableApiV2QueryLink { get; set; }
         public string RoutePrefix { get; set; }
         public int LimiterRequests { get; set; }
         public int LimiterTimespan { get; set; }

--- a/PXWeb/Code/Settings/Interfaces/IApiSettings.cs
+++ b/PXWeb/Code/Settings/Interfaces/IApiSettings.cs
@@ -14,6 +14,17 @@ namespace PXWeb
         /// URL root. root of API url
         /// </summary>
         string UrlRoot { get; }
+
+
+        /// <summary>
+        /// If Api-V2 links should be shown in the results view
+        /// </summary>
+        bool EnableApiV2QueryLink { get; }
+
+        /// <summary>
+        /// URL root. root of API-V2 url
+        /// </summary>
+        string UrlRootV2 { get; }
         /// <summary>
         /// URL route identifying API request
         /// </summary>

--- a/PXWeb/Presentation.master.cs
+++ b/PXWeb/Presentation.master.cs
@@ -273,6 +273,8 @@ namespace PXWeb
             }
 
             TableQueryInformation.URLRoot = PXWeb.Settings.Current.Features.Api.UrlRoot;
+            TableQueryInformation.URLRootV2 = PXWeb.Settings.Current.Features.Api.UrlRootV2;
+            TableQueryInformation.EnableApiV2QueryLink = PXWeb.Settings.Current.Features.Api.EnableApiV2QueryLink;
             TableQueryInformation.Database = db; 
             TableQueryInformation.Path = PxUrlObject.Path;
             TableQueryInformation.Table = PxUrlObject.Table;

--- a/PXWeb/Resources/Languages/pxlang.sv.xml
+++ b/PXWeb/Resources/Languages/pxlang.sv.xml
@@ -411,10 +411,12 @@
   <sentence name="CtrlTableQueryShowInformationTooltip" value="Få information hur Du kan göra denna tabell tillgänglig i Din applikation" />
   <sentence name="CtrlTableQueryHideInformation" value="Dölj information" />
   <sentence name="CtrlTableQueryInformationText" value="Skicka (POST) följande JSON fråga till nedanstående URL för att nå denna tabell i Din applikation" />
+  <sentence name="CtrlTableQueryInformationV2Text" value="Skicka en GET-request till följande URL för att nå denna tabell" />
   <sentence name="CtrlTableQueryUrlCaption" value="URL:" />
   <sentence name="CtrlTableQueryQueryCaption" value="JSON fråga:" />
   <sentence name="CtrlTableQueryMoreInformation" value="Mer information" />
   <sentence name="CtrlTableQuerySaveQuery" value="Spara API-fråga (json)" />
+	<sentence name="CtrlTableQueryCopy" value="Kopiera" />
   <sentence name="CtrlNavigationFlowStep1" value="Välj tabell" />
   <sentence name="CtrlNavigationFlowStep1ScreenReader" value="Ikon som representerar sidan där du väljer tabell" />
   <sentence name="CtrlNavigationFlowStep2" value="Välj variabel" />

--- a/PXWeb/Resources/Languages/pxlang.xml
+++ b/PXWeb/Resources/Languages/pxlang.xml
@@ -487,10 +487,12 @@
 	 <sentence name="CtrlTableQueryShowInformationTooltip" value="Get information about how you can connect to this table from your application" />
 	 <sentence name="CtrlTableQueryHideInformation" value="Hide" />
 	 <sentence name="CtrlTableQueryInformationText" value="POST the following JSON query to the URL below to access this table from your application." />
+	 <sentence name="CtrlTableQueryV2InformationText" value="Send a GET request to the URL below to access this table." />
 	 <sentence name="CtrlTableQueryUrlCaption" value="URL:" />
 	 <sentence name="CtrlTableQueryQueryCaption" value="JSON query:" />
 	 <sentence name="CtrlTableQueryMoreInformation" value="More information" />
     <sentence name="CtrlTableQuerySaveQuery" value="Save API query (json)" />
+	<sentence name="CtrlTableQueryCopy" value="Copy" />
     
    <sentence name="CtrlNavigationFlowSectionScreenReader" value="Overview of the three steps in the process to get the data."/>
    <sentence name="CtrlNavigationFlowExplainScreenReader" value="The 3 steps are Choose table, Choose variable and Show result. You are currently at "/>
@@ -1300,6 +1302,10 @@
 	 <sentence name="PxWebAdminFeaturesApiGeneralRoutePrefixInfo" value="URL route identifying API requests." />
    <sentence name="PxWebAdminFeaturesApiGeneralUrlRoot" value="URL root API" />
    <sentence name="PxWebAdminFeaturesApiGeneralUrlRootInfo" value="Specify URL root for API on other instance" />
+	<sentence name="PxWebAdminFeaturesApiGeneralUrlRootV2" value="URL root API-V2" />
+	<sentence name="PxWebAdminFeaturesApiGeneralUrlRootInfoV2" value="Specify URL root for API-V2 on other instance" />
+	<sentence name="PxWebAdminFeaturesApiGeneralEnableApiV2QueryLink" value="Enable API-V2 query link" />
+	<sentence name="PxWebAdminFeaturesApiGeneralEnableApiV2QueryLinkInfo" value="Enable API-V2 link in the results view" />
 	 <sentence name="PxWebAdminFeaturesApiGeneralMaxValuesReturned" value="Max values returned" />
 	 <sentence name="PxWebAdminFeaturesApiGeneralMaxValuesReturnedInfo" value="Maximum number of values returned from request" />
 	 <sentence name="PxWebAdminFeaturesApiGeneralLimiterRequests" value="Limiter requests" />

--- a/PXWeb/Resources/PX/Databases/Example/Menu.xml
+++ b/PXWeb/Resources/PX/Databases/Example/Menu.xml
@@ -21,9 +21,9 @@
           <Attribute name="Var2NumberOfValues">5</Attribute>
           <Attribute name="size">1933</Attribute>
           <Attribute name="cells">40</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060611 14:31</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-06-11 14:31:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -51,9 +51,9 @@
           <Attribute name="Var4NumberOfValues">2</Attribute>
           <Attribute name="size">133855</Attribute>
           <Attribute name="cells">46176</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:33</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:33:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -84,9 +84,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">5091</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -112,9 +112,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8371</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -140,9 +140,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8368</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -168,9 +168,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">5714</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -206,9 +206,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8697</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -233,9 +233,9 @@
           <Attribute name="Var3NumberOfValues">2</Attribute>
           <Attribute name="size">2675</Attribute>
           <Attribute name="cells">84</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090213 07:19</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-02-13 07:19:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -256,9 +256,9 @@
           <Attribute name="size">2689</Attribute>
           <Attribute name="cells">84</Attribute>
           <Attribute name="autoOpen">true</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090213 07:19</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-02-13 07:19:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -283,9 +283,9 @@
           <Attribute name="Var3NumberOfValues">2</Attribute>
           <Attribute name="size">2759</Attribute>
           <Attribute name="cells">84</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090213 07:19</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-02-13 07:19:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -305,9 +305,9 @@
           <Attribute name="Var3NumberOfValues">2</Attribute>
           <Attribute name="size">2734</Attribute>
           <Attribute name="cells">84</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090213 07:19</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-02-13 07:19:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -332,9 +332,9 @@
           <Attribute name="Var3NumberOfValues">2</Attribute>
           <Attribute name="size">2704</Attribute>
           <Attribute name="cells">84</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090213 07:19</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-02-13 07:19:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -351,9 +351,9 @@
           <Attribute name="Var2NumberOfValues">13</Attribute>
           <Attribute name="size">3036</Attribute>
           <Attribute name="cells">117</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090604 09:58</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-06-04 09:58:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -373,9 +373,9 @@
           <Attribute name="Var3NumberOfValues">16</Attribute>
           <Attribute name="size">8992583</Attribute>
           <Attribute name="cells">1388544</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090623 16:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-06-23 16:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -410,9 +410,9 @@
             <Attribute name="Var5NumberOfValues">2</Attribute>
             <Attribute name="size">4248</Attribute>
             <Attribute name="cells">48</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -438,9 +438,9 @@
             <Attribute name="Var5NumberOfValues">2</Attribute>
             <Attribute name="size">4241</Attribute>
             <Attribute name="cells">48</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -471,9 +471,9 @@
             <Attribute name="Var5NumberOfValues">2</Attribute>
             <Attribute name="size">4210</Attribute>
             <Attribute name="cells">48</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -499,9 +499,9 @@
             <Attribute name="Var5NumberOfValues">2</Attribute>
             <Attribute name="size">4084</Attribute>
             <Attribute name="cells">48</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -527,9 +527,9 @@
             <Attribute name="Var5NumberOfValues">2</Attribute>
             <Attribute name="size">4241</Attribute>
             <Attribute name="cells">48</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -561,9 +561,9 @@
             <Attribute name="size">5090</Attribute>
             <Attribute name="cells">48</Attribute>
             <Attribute name="autoOpen">true</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -590,9 +590,9 @@
             <Attribute name="size">5105</Attribute>
             <Attribute name="cells">48</Attribute>
             <Attribute name="autoOpen">true</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -618,9 +618,9 @@
             <Attribute name="Var5NumberOfValues">2</Attribute>
             <Attribute name="size">8369</Attribute>
             <Attribute name="cells">48</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -652,9 +652,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">41113</Attribute>
           <Attribute name="cells">9984</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -677,9 +677,9 @@
           <Attribute name="Var4NumberOfValues">4</Attribute>
           <Attribute name="size">62817</Attribute>
           <Attribute name="cells">9984</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20050208 17:19</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2005-02-08 17:19:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -702,9 +702,9 @@
           <Attribute name="Var4NumberOfValues">4</Attribute>
           <Attribute name="size">61541</Attribute>
           <Attribute name="cells">9984</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20050208 17:19</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2005-02-08 17:19:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -730,9 +730,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">41193</Attribute>
           <Attribute name="cells">9984</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -758,9 +758,9 @@
           <Attribute name="Var5NumberOfValues">1</Attribute>
           <Attribute name="size">43673</Attribute>
           <Attribute name="cells">9984</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -780,9 +780,9 @@
           <Attribute name="Var3NumberOfValues">2</Attribute>
           <Attribute name="size">2372</Attribute>
           <Attribute name="cells">58</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060302 02:01</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-03-02 02:01:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -799,9 +799,9 @@
           <Attribute name="Var2NumberOfValues">11</Attribute>
           <Attribute name="size">9977</Attribute>
           <Attribute name="cells">726</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060707 08:37</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-07-07 08:37:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -818,9 +818,9 @@
           <Attribute name="Var2NumberOfValues">11</Attribute>
           <Attribute name="size">14755</Attribute>
           <Attribute name="cells">726</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060707 08:37</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-07-07 08:37:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -851,9 +851,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">3620</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -888,9 +888,9 @@
             <Attribute name="Var5NumberOfValues">2</Attribute>
             <Attribute name="size">5742</Attribute>
             <Attribute name="cells">48</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:24</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -916,9 +916,9 @@
           <Attribute name="Var3NumberOfValues">16</Attribute>
           <Attribute name="size">8992545</Attribute>
           <Attribute name="cells">1388544</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090623 16:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-06-23 16:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -935,9 +935,9 @@
           <Attribute name="Var2NumberOfValues">27</Attribute>
           <Attribute name="size">4650</Attribute>
           <Attribute name="cells">324</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090708 12:44</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-07-08 12:44:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -951,9 +951,9 @@
           <Attribute name="Var1NumberOfValues">58</Attribute>
           <Attribute name="size">3476</Attribute>
           <Attribute name="cells">58</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090708 12:44</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-07-08 12:44:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -984,9 +984,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">5091</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1012,9 +1012,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8697</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1040,9 +1040,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8368</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1068,9 +1068,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">5714</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1102,9 +1102,9 @@
           <Attribute name="size">4036</Attribute>
           <Attribute name="cells">48</Attribute>
           <Attribute name="autoOpen">true</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1128,9 +1128,9 @@
           <Attribute name="size">2720</Attribute>
           <Attribute name="cells">24</Attribute>
           <Attribute name="autoOpen">true</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1153,9 +1153,9 @@
           <Attribute name="Var4NumberOfValues">2</Attribute>
           <Attribute name="size">1933</Attribute>
           <Attribute name="cells">24</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1181,9 +1181,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">2989</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1209,9 +1209,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">3158</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1238,9 +1238,9 @@
           <Attribute name="size">2990</Attribute>
           <Attribute name="cells">48</Attribute>
           <Attribute name="autoOpen">true</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1267,9 +1267,9 @@
           <Attribute name="size">3087</Attribute>
           <Attribute name="cells">48</Attribute>
           <Attribute name="autoOpen">true</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1295,9 +1295,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">3294</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1323,9 +1323,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">3292</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1351,9 +1351,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">3820</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1380,9 +1380,9 @@
           <Attribute name="size">4225</Attribute>
           <Attribute name="cells">48</Attribute>
           <Attribute name="autoOpen">true</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1413,9 +1413,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">2085</Attribute>
           <Attribute name="cells">96</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1441,9 +1441,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">2086</Attribute>
           <Attribute name="cells">96</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1469,9 +1469,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">2098</Attribute>
           <Attribute name="cells">96</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1497,9 +1497,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">2098</Attribute>
           <Attribute name="cells">96</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1525,9 +1525,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">2098</Attribute>
           <Attribute name="cells">96</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1553,9 +1553,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">2201</Attribute>
           <Attribute name="cells">96</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1586,9 +1586,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">151034</Attribute>
           <Attribute name="cells">33936</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1608,9 +1608,9 @@
           <Attribute name="Var3NumberOfValues">6</Attribute>
           <Attribute name="size">1922</Attribute>
           <Attribute name="cells">90</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20070215 09:51</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2007-02-15 09:51:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1636,9 +1636,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">4201</Attribute>
           <Attribute name="cells">288</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1664,9 +1664,9 @@
           <Attribute name="Var5NumberOfValues">3</Attribute>
           <Attribute name="size">5232</Attribute>
           <Attribute name="cells">432</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 15:20</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-02-09 15:20:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1693,9 +1693,9 @@
           <Attribute name="size">4293</Attribute>
           <Attribute name="cells">48</Attribute>
           <Attribute name="autoOpen">true</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1719,9 +1719,9 @@
           <Attribute name="size">1715</Attribute>
           <Attribute name="cells">24</Attribute>
           <Attribute name="autoOpen">true</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1747,9 +1747,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">3294</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1775,9 +1775,9 @@
           <Attribute name="Var5NumberOfValues">9</Attribute>
           <Attribute name="size">16124</Attribute>
           <Attribute name="cells">3240</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060209 11:31</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-02-09 11:31:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1803,9 +1803,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">2895</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1827,9 +1827,9 @@
           <Attribute name="Var2NumberOfValues">13</Attribute>
           <Attribute name="size">2993</Attribute>
           <Attribute name="cells">117</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20090604 09:58</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2009-06-04 09:58:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1867,9 +1867,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">5091</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1895,9 +1895,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8371</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1923,9 +1923,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8368</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1951,9 +1951,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">5714</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -1989,9 +1989,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8697</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -2027,9 +2027,9 @@
             <Attribute name="size">5090</Attribute>
             <Attribute name="cells">48</Attribute>
             <Attribute name="autoOpen">true</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -2056,9 +2056,9 @@
             <Attribute name="size">5105</Attribute>
             <Attribute name="cells">48</Attribute>
             <Attribute name="autoOpen">true</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -2084,9 +2084,9 @@
             <Attribute name="Var5NumberOfValues">2</Attribute>
             <Attribute name="size">8369</Attribute>
             <Attribute name="cells">48</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:25</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -2109,9 +2109,9 @@
           <Attribute name="Var2NumberOfValues">11</Attribute>
           <Attribute name="size">14755</Attribute>
           <Attribute name="cells">726</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20060707 08:37</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:24</Published>
           <LastUpdated>2006-07-07 08:37:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -2146,9 +2146,9 @@
             <Attribute name="Var5NumberOfValues">2</Attribute>
             <Attribute name="size">5742</Attribute>
             <Attribute name="cells">48</Attribute>
-            <Attribute name="updated">20220628 16:40</Attribute>
+            <Attribute name="updated">20230703 11:30</Attribute>
             <Attribute name="modified">20040212 16:28</Attribute>
-            <Published>2022-06-28 16:40:57</Published>
+            <Published>2023-07-03 11:30:24</Published>
             <LastUpdated>2004-02-12 16:28:00</LastUpdated>
             <StartTime></StartTime>
             <EndTime></EndTime>
@@ -2180,9 +2180,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">5091</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -2208,9 +2208,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8697</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -2236,9 +2236,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">8368</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>
@@ -2264,9 +2264,9 @@
           <Attribute name="Var5NumberOfValues">2</Attribute>
           <Attribute name="size">5714</Attribute>
           <Attribute name="cells">48</Attribute>
-          <Attribute name="updated">20220628 16:40</Attribute>
+          <Attribute name="updated">20230703 11:30</Attribute>
           <Attribute name="modified">20040212 16:28</Attribute>
-          <Published>2022-06-28 16:40:57</Published>
+          <Published>2023-07-03 11:30:25</Published>
           <LastUpdated>2004-02-12 16:28:00</LastUpdated>
           <StartTime></StartTime>
           <EndTime></EndTime>

--- a/PXWeb/Resources/Styles/main-pxweb.css
+++ b/PXWeb/Resources/Styles/main-pxweb.css
@@ -3528,6 +3528,12 @@ $scrollbar-color: #b0b0b0;
   margin-top: 5px;
 }
 
+#pxwebcontent .tablequery_V2caption {
+    font-size: 20px;
+    display: block;
+    font-weight: bold;
+}
+
 #pxwebcontent .tablequery_url {
   display: block;
   width: 95%;
@@ -3567,13 +3573,16 @@ $scrollbar-color: #b0b0b0;
   color: #fff;
 }
 
+#pxwebcontent .tablequery_copy {
+}
+
 /* **********************************  _tablequery.scss TODO in real use? *********************************** */
 #pxwebcontent .textsearch select {
-  margin: 10px 0;
-  height: 100px;
-  width: 164px;
-  clear: both;
-  display: block;
+    margin: 10px 0;
+    height: 100px;
+    width: 164px;
+    clear: both;
+    display: block;
 }
 
 #pxwebcontent .textsearch input[type=text] {

--- a/PXWeb/Resources/Styles/scss/pxweb/_tablequery.scss
+++ b/PXWeb/Resources/Styles/scss/pxweb/_tablequery.scss
@@ -17,12 +17,17 @@
   font-weight: bold;
   margin-top: 5px;
 }
+#pxwebcontent .tablequery_V2caption {
+    font-size: 20px;
+    display: block;
+    font-weight: bold;
+}
 
 #pxwebcontent .tablequery_url {
-  display: block;
-  width: 95%;
-  @include SourceCodeProTablequery_url;
-  font-size: 14px;
+    display: block;
+    width: 95%;
+    @include SourceCodeProTablequery_url;
+    font-size: 14px;
 }
 
 #pxwebcontent .tablequery_querycaption {
@@ -53,4 +58,10 @@
   float: left;
   background: $pxweb-green-4;
   color: $pxweb-white;
+}
+
+#pxwebcontent #urlV2container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
 }


### PR DESCRIPTION
Links to api-v2 endpoints can now be enabled in settings, these work alongside Api 1.0 links with POST data.

fix #471 