### PR TITLE
Now redirects to selection-page if paxiom and url dont match

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 === Release of PxWeb 2024 v1 ===
+- Fix redirect to selection page for change language(issues/619) and in presentation-page if paxiom and the url dont match(issues/624)
 === Release of PxWeb 2023 v1 ===
 - New version of PCaxis.Serializers with JSON-STAT2 and Parquet
 - New version of PcAxis.Query.1.0.8 #367

--- a/PXWeb/Presentation.master.cs
+++ b/PXWeb/Presentation.master.cs
@@ -74,8 +74,28 @@ namespace PXWeb
             Page.MaintainScrollPositionOnPostBack = true;
 
 
+            bool doRedirect = false;
 
-            if (PCAxis.Web.Core.Management.PaxiomManager.PaxiomModel == null || !PaxiomManager.PaxiomModel.IsComplete)
+            var pxmodel = PCAxis.Web.Core.Management.PaxiomManager.PaxiomModel;
+
+            if (pxmodel == null || !pxmodel.IsComplete)
+            {
+                doRedirect = true;
+            }
+            else
+            {
+                if (PxUrlObject.Table.ToLower().EndsWith(".px"))
+                {
+                    // Asuming pxmodel.Meta.MainTable must be the full path to px-file.
+                    doRedirect = ! pxmodel.Meta.MainTable.ToLower().EndsWith(PxUrlObject.Table.ToLower());
+                }
+                else
+                {
+                    doRedirect = pxmodel.Meta.MainTable.ToLower() != PxUrlObject.Table.ToLower();
+                }
+            }
+
+            if (doRedirect)
             {
                 List<LinkManager.LinkItem> linkItems = new List<LinkManager.LinkItem>();
                 linkItems.Add(new LinkManager.LinkItem(PxUrl.LANGUAGE_KEY, PxUrlObject.Language));
@@ -87,7 +107,9 @@ namespace PXWeb
                 Response.Redirect(rurl);
             }
 
-            lblFullscreenTitle.Text = PaxiomManager.PaxiomModel.Meta.Title;
+
+
+            lblFullscreenTitle.Text = pxmodel.Meta.Title;
             InitializeTableHeadings();
 
             if (!IsPostBack)


### PR DESCRIPTION
See issue #624.

This tries to make sure that the  paxiom from PaxiomManager.PaxiomModel  is made for the same table as the url requests.

If it does a redirect when it should not, the user will be stuck in the selection-page, so we have to be sure... 