### PR TITLE
Update NuGet packages and target framework to net8.0

### DIFF
--- a/PCAxis.Api/PCAxis.Api.csproj
+++ b/PCAxis.Api/PCAxis.Api.csproj
@@ -156,19 +156,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core">
-      <Version>1.42.0</Version>
+      <Version>1.47.2</Version>
     </PackageReference>
     <PackageReference Include="Azure.Identity">
-      <Version>1.12.0</Version>
+      <Version>1.15.0</Version>
     </PackageReference>
     <PackageReference Include="Irony.NetCore">
       <Version>1.1.11</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.SqlClient">
-      <Version>5.2.1</Version>
+      <Version>5.2.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal">
-      <Version>4.63.0</Version>
+      <Version>4.73.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
       <Version>8.0.1</Version>
@@ -186,16 +186,16 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.Menu.ConfigDatamodelMenu">
-      <Version>1.0.8</Version>
-    </PackageReference>
-    <PackageReference Include="PcAxis.Query">
       <Version>1.0.9</Version>
     </PackageReference>
+    <PackageReference Include="PcAxis.Query">
+      <Version>1.0.10</Version>
+    </PackageReference>
     <PackageReference Include="PCAxis.Serializers">
-      <Version>1.4.1</Version>
+      <Version>1.9.1</Version>
     </PackageReference>
     <PackageReference Include="PcAxis.Sql">
-      <Version>1.2.4</Version>
+      <Version>1.4.5</Version>
     </PackageReference>
     <PackageReference Include="SixLabors.Fonts">
       <Version>1.0.0</Version>
@@ -264,7 +264,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Memory.Data">
-      <Version>8.0.0</Version>
+      <Version>8.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>
@@ -321,7 +321,7 @@
       <Version>4.3.2</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Cryptography.Xml">
-      <Version>8.0.1</Version>
+      <Version>8.0.2</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Permissions">
       <Version>8.0.0</Version>
@@ -333,7 +333,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>8.0.5</Version>
+      <Version>8.0.6</Version>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions">
       <Version>4.3.1</Version>

--- a/PCAxis.Charting/PxChart/PCAxis.Charting.csproj
+++ b/PCAxis.Charting/PxChart/PCAxis.Charting.csproj
@@ -118,11 +118,14 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="log4net">
+      <Version>3.1.0</Version>
+    </PackageReference>
     <PackageReference Include="PcAxis.Core">
-      <Version>1.2.5</Version>
+      <Version>1.2.6</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.Menu">
-      <Version>1.0.3</Version>
+      <Version>1.0.4</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.PxExtend">
       <Version>1.0.4</Version>

--- a/PCAxis.Charts/PCAxis.Chart.csproj
+++ b/PCAxis.Charts/PCAxis.Chart.csproj
@@ -121,8 +121,11 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="log4net">
+      <Version>3.1.0</Version>
+    </PackageReference>
     <PackageReference Include="PcAxis.Core">
-      <Version>1.2.5</Version>
+      <Version>1.2.6</Version>
     </PackageReference>
     <PackageReference Include="System.Security.AccessControl">
       <Version>6.0.1</Version>

--- a/PCAxis.Excel.Web.Controls/PCAxis.Excel.Web.Controls.csproj
+++ b/PCAxis.Excel.Web.Controls/PCAxis.Excel.Web.Controls.csproj
@@ -147,10 +147,10 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="PcAxis.Query">
-      <Version>1.0.9</Version>
+      <Version>1.0.10</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.Serializers">
-      <Version>1.4.1</Version>
+      <Version>1.9.1</Version>
     </PackageReference>
     <PackageReference Include="SixLabors.Fonts">
       <Version>1.0.0</Version>
@@ -270,7 +270,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>8.0.5</Version>
+      <Version>8.0.6</Version>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions">
       <Version>4.3.1</Version>

--- a/PCAxis.Html5Table.Web.Controls/PCAxis.Html5Table.Web.Controls.csproj
+++ b/PCAxis.Html5Table.Web.Controls/PCAxis.Html5Table.Web.Controls.csproj
@@ -99,10 +99,10 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="PcAxis.Query">
-      <Version>1.0.9</Version>
+      <Version>1.0.10</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.Serializers">
-      <Version>1.4.1</Version>
+      <Version>1.9.1</Version>
     </PackageReference>
     <PackageReference Include="SixLabors.Fonts">
       <Version>1.0.0</Version>
@@ -222,7 +222,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>8.0.5</Version>
+      <Version>8.0.6</Version>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions">
       <Version>4.3.1</Version>

--- a/PCAxis.JsonStat.Web.Controls/PCAxis.JsonStat.Web.Controls.csproj
+++ b/PCAxis.JsonStat.Web.Controls/PCAxis.JsonStat.Web.Controls.csproj
@@ -100,10 +100,10 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="PcAxis.Query">
-      <Version>1.0.9</Version>
+      <Version>1.0.10</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.Serializers">
-      <Version>1.4.1</Version>
+      <Version>1.9.1</Version>
     </PackageReference>
     <PackageReference Include="SixLabors.Fonts">
       <Version>1.0.0</Version>
@@ -223,7 +223,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>8.0.5</Version>
+      <Version>8.0.6</Version>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions">
       <Version>4.3.1</Version>

--- a/PCAxis.JsonStat2.Web.Controls/PCAxis.JsonStat2.Web.Controls.csproj
+++ b/PCAxis.JsonStat2.Web.Controls/PCAxis.JsonStat2.Web.Controls.csproj
@@ -98,10 +98,10 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="PcAxis.Query">
-      <Version>1.0.9</Version>
+      <Version>1.0.10</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.Serializers">
-      <Version>1.4.1</Version>
+      <Version>1.9.1</Version>
     </PackageReference>
     <PackageReference Include="SixLabors.Fonts">
       <Version>1.0.0</Version>
@@ -221,7 +221,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>8.0.5</Version>
+      <Version>8.0.6</Version>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions">
       <Version>4.3.1</Version>

--- a/PCAxis.Search/PCAxis.Search.csproj
+++ b/PCAxis.Search/PCAxis.Search.csproj
@@ -83,19 +83,22 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core">
-      <Version>1.42.0</Version>
+      <Version>1.47.2</Version>
     </PackageReference>
     <PackageReference Include="Azure.Identity">
-      <Version>1.12.0</Version>
+      <Version>1.15.0</Version>
+    </PackageReference>
+    <PackageReference Include="log4net">
+      <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Lucene.Net">
       <Version>3.0.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.SqlClient">
-      <Version>5.2.1</Version>
+      <Version>5.2.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal">
-      <Version>4.63.0</Version>
+      <Version>4.73.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
       <Version>8.0.1</Version>
@@ -104,13 +107,13 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="PcAxis.Core">
-      <Version>1.2.5</Version>
+      <Version>1.2.6</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.Menu">
-      <Version>1.0.3</Version>
+      <Version>1.0.4</Version>
     </PackageReference>
     <PackageReference Include="PcAxis.Sql">
-      <Version>1.2.4</Version>
+      <Version>1.4.5</Version>
     </PackageReference>
     <PackageReference Include="SharpZipLib">
       <Version>1.3.3</Version>
@@ -131,7 +134,7 @@
       <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Memory.Data">
-      <Version>8.0.0</Version>
+      <Version>8.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>
@@ -152,7 +155,7 @@
       <Version>4.3.2</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Cryptography.Xml">
-      <Version>8.0.1</Version>
+      <Version>8.0.2</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Permissions">
       <Version>8.0.0</Version>
@@ -161,7 +164,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>8.0.5</Version>
+      <Version>8.0.6</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/PCAxis.Web.Controls/PCAxis.Web.Controls.vbproj
+++ b/PCAxis.Web.Controls/PCAxis.Web.Controls.vbproj
@@ -748,13 +748,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="PCAxis.Menu">
-      <Version>1.0.3</Version>
+      <Version>1.0.4</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.Metadata">
-      <Version>1.0.3</Version>
+      <Version>1.0.4</Version>
     </PackageReference>
     <PackageReference Include="PcAxis.Query">
-      <Version>1.0.9</Version>
+      <Version>1.0.10</Version>
     </PackageReference>
     <PackageReference Include="System.Security.AccessControl">
       <Version>6.0.1</Version>

--- a/PCAxis.Web.Core/PCAxis.Web.Core.vbproj
+++ b/PCAxis.Web.Core/PCAxis.Web.Core.vbproj
@@ -205,8 +205,11 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="log4net">
+      <Version>3.1.0</Version>
+    </PackageReference>
     <PackageReference Include="PcAxis.Query">
-      <Version>1.0.9</Version>
+      <Version>1.0.10</Version>
     </PackageReference>
     <PackageReference Include="System.Security.AccessControl">
       <Version>6.0.1</Version>

--- a/PX.Json.Web.Controls/PX.Json.Web.Controls.csproj
+++ b/PX.Json.Web.Controls/PX.Json.Web.Controls.csproj
@@ -99,10 +99,10 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="PcAxis.Query">
-      <Version>1.0.9</Version>
+      <Version>1.0.10</Version>
     </PackageReference>
     <PackageReference Include="PCAxis.Serializers">
-      <Version>1.4.1</Version>
+      <Version>1.9.1</Version>
     </PackageReference>
     <PackageReference Include="SixLabors.Fonts">
       <Version>1.0.0</Version>
@@ -222,7 +222,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Text.Json">
-      <Version>8.0.5</Version>
+      <Version>8.0.6</Version>
     </PackageReference>
     <PackageReference Include="System.Text.RegularExpressions">
       <Version>4.3.1</Version>

--- a/PXWeb/PXWeb.csproj
+++ b/PXWeb/PXWeb.csproj
@@ -58,11 +58,11 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Azure.Core, Version=1.42.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Core.1.42.0\lib\net472\Azure.Core.dll</HintPath>
+    <Reference Include="Azure.Core, Version=1.47.2.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Core.1.47.2\lib\net472\Azure.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Azure.Identity, Version=1.12.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\Azure.Identity.1.12.0\lib\netstandard2.0\Azure.Identity.dll</HintPath>
+    <Reference Include="Azure.Identity, Version=1.15.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Azure.Identity.1.15.0\lib\netstandard2.0\Azure.Identity.dll</HintPath>
     </Reference>
     <Reference Include="ClosedXML, Version=0.97.0.0, Culture=neutral, PublicKeyToken=fd1eb21b62ae805b, processorArchitecture=MSIL">
       <HintPath>..\packages\ClosedXML.0.97.0\lib\netstandard2.0\ClosedXML.dll</HintPath>
@@ -76,21 +76,27 @@
     <Reference Include="Irony, Version=1.1.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Irony.NetCore.1.1.11\lib\netstandard2.0\Irony.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.3.0.3\lib\net462\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=3.1.0.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.3.1.0\lib\net462\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.SqlClient, Version=5.0.0.0, Culture=neutral, PublicKeyToken=23ec7fc2d6eaa4a5, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Data.SqlClient.5.2.1\lib\net462\Microsoft.Data.SqlClient.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Data.SqlClient.5.2.3\lib\net462\Microsoft.Data.SqlClient.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Identity.Client, Version=4.63.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.4.63.0\lib\net472\Microsoft.Identity.Client.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.2, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.8.0.2\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Identity.Client.Extensions.Msal, Version=4.63.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.Extensions.Msal.4.63.0\lib\netstandard2.0\Microsoft.Identity.Client.Extensions.Msal.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=8.0.0.3, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.8.0.3\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Identity.Client, Version=4.73.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.4.73.1\lib\net472\Microsoft.Identity.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Identity.Client.Extensions.Msal, Version=4.73.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.Extensions.Msal.4.73.1\lib\netstandard2.0\Microsoft.Identity.Client.Extensions.Msal.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Abstractions, Version=8.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.8.0.1\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
@@ -135,50 +141,50 @@
       <HintPath>..\packages\Ninject.Web.WebApi.WebHost.3.3.1\lib\net45\Ninject.Web.WebApi.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="Oracle.ManagedDataAccess, Version=2.0.19.1, Culture=neutral, PublicKeyToken=89b483f429c47342, processorArchitecture=MSIL">
-      <HintPath>..\packages\Oracle.ManagedDataAccess.Core.2.19.230\lib\netstandard2.0\Oracle.ManagedDataAccess.dll</HintPath>
+      <HintPath>..\packages\Oracle.ManagedDataAccess.Core.2.19.280\lib\netstandard2.0\Oracle.ManagedDataAccess.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PcAxis.Core.1.2.5\lib\netstandard2.0\PCAxis.Core.dll</HintPath>
+      <HintPath>..\packages\PcAxis.Core.1.2.6\lib\netstandard2.0\PCAxis.Core.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Menu, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Menu.1.0.3\lib\netstandard2.0\PCAxis.Menu.dll</HintPath>
+      <HintPath>..\packages\PCAxis.Menu.1.0.4\lib\netstandard2.0\PCAxis.Menu.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Menu.ConfigDatamodelMenu, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Menu.ConfigDatamodelMenu.1.0.8\lib\netstandard2.0\PCAxis.Menu.ConfigDatamodelMenu.dll</HintPath>
+      <HintPath>..\packages\PCAxis.Menu.ConfigDatamodelMenu.1.0.9\lib\netstandard2.0\PCAxis.Menu.ConfigDatamodelMenu.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Menu.MsSqlDatamodelMenu, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Menu.MsSqlDatamodelMenu.1.0.4\lib\netstandard2.0\PCAxis.Menu.MsSqlDatamodelMenu.dll</HintPath>
+      <HintPath>..\packages\PCAxis.Menu.MsSqlDatamodelMenu.1.0.5\lib\netstandard2.0\PCAxis.Menu.MsSqlDatamodelMenu.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Menu.OracleDatamodelMenu, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Menu.OracleDatamodelMenu.1.0.3\lib\netstandard2.0\PCAxis.Menu.OracleDatamodelMenu.dll</HintPath>
+      <HintPath>..\packages\PCAxis.Menu.OracleDatamodelMenu.1.0.4\lib\netstandard2.0\PCAxis.Menu.OracleDatamodelMenu.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Metadata, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PCAxis.Metadata.1.0.3\lib\netstandard2.0\PCAxis.Metadata.dll</HintPath>
+      <HintPath>..\packages\PCAxis.Metadata.1.0.4\lib\netstandard2.0\PCAxis.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Query, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PcAxis.Query.1.0.9\lib\netstandard2.0\PCAxis.Query.dll</HintPath>
+      <HintPath>..\packages\PcAxis.Query.1.0.10\lib\netstandard2.0\PCAxis.Query.dll</HintPath>
     </Reference>
     <Reference Include="PCAxis.Sql, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PcAxis.Sql.1.2.4\lib\netstandard2.0\PCAxis.Sql.dll</HintPath>
+      <HintPath>..\packages\PcAxis.Sql.1.4.5\lib\netstandard2.0\PCAxis.Sql.dll</HintPath>
     </Reference>
     <Reference Include="Px.Dcat, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Px.Dcat.2.0.6\lib\netstandard2.0\Px.Dcat.dll</HintPath>
     </Reference>
     <Reference Include="PXWeb.SavedQuery.MsSql, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PXWeb.SavedQuery.MsSql.1.0.4\lib\netstandard2.0\PXWeb.SavedQuery.MsSql.dll</HintPath>
+      <HintPath>..\packages\PXWeb.SavedQuery.MsSql.1.0.5\lib\netstandard2.0\PXWeb.SavedQuery.MsSql.dll</HintPath>
     </Reference>
     <Reference Include="PXWeb.SavedQuery.Oracle, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PXWeb.SavedQuery.Oracle.1.0.6\lib\netstandard2.0\PXWeb.SavedQuery.Oracle.dll</HintPath>
+      <HintPath>..\packages\PXWeb.SavedQuery.Oracle.1.0.7\lib\netstandard2.0\PXWeb.SavedQuery.Oracle.dll</HintPath>
     </Reference>
     <Reference Include="SixLabors.Fonts, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d998eea7b14cab13, processorArchitecture=MSIL">
       <HintPath>..\packages\SixLabors.Fonts.1.0.0\lib\netstandard2.0\SixLabors.Fonts.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    <Reference Include="System.Buffers, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.6.0\lib\net462\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.ClientModel, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ClientModel.1.0.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
+    <Reference Include="System.ClientModel, Version=1.6.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ClientModel.1.6.0\lib\netstandard2.0\System.ClientModel.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration.ConfigurationManager, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -221,11 +227,11 @@
     <Reference Include="System.IO.Packaging, Version=8.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Packaging.8.0.1\lib\net462\System.IO.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.6.0\lib\net462\System.Memory.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory.Data, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.Data.8.0.0\lib\net462\System.Memory.Data.dll</HintPath>
+    <Reference Include="System.Memory.Data, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.Data.8.0.1\lib\net462\System.Memory.Data.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -237,8 +243,8 @@
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.6.0.0\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
@@ -246,8 +252,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
@@ -281,8 +287,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.Xml, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Xml.8.0.1\lib\net462\System.Security.Cryptography.Xml.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.Xml, Version=8.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Xml.8.0.2\lib\net462\System.Security.Cryptography.Xml.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Permissions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Permissions.8.0.0\lib\net462\System.Security.Permissions.dll</HintPath>
@@ -294,8 +300,8 @@
     <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=8.0.0.6, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.8.0.6\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/PXWeb/packages.config
+++ b/PXWeb/packages.config
@@ -1,23 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Azure.Core" version="1.42.0" targetFramework="net48" />
-  <package id="Azure.Identity" version="1.12.0" targetFramework="net48" />
+  <package id="Azure.Core" version="1.47.2" targetFramework="net48" />
+  <package id="Azure.Identity" version="1.15.0" targetFramework="net48" />
   <package id="ClosedXML" version="0.97.0" targetFramework="net48" />
   <package id="DocumentFormat.OpenXml" version="2.16.0" targetFramework="net48" />
   <package id="ExcelNumberFormat" version="1.1.0" targetFramework="net48" />
   <package id="Irony.NetCore" version="1.1.11" targetFramework="net48" />
   <package id="jQuery" version="3.5.1" targetFramework="net48" />
-  <package id="log4net" version="3.0.3" targetFramework="net48" />
+  <package id="log4net" version="3.1.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi" version="5.3.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.Client" version="6.0.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.3.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.3.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net48" />
-  <package id="Microsoft.Data.SqlClient" version="5.2.1" targetFramework="net48" />
+  <package id="Microsoft.Data.SqlClient" version="5.2.3" targetFramework="net48" />
   <package id="Microsoft.Data.SqlClient.SNI" version="5.2.0" targetFramework="net48" />
-  <package id="Microsoft.Identity.Client" version="4.63.0" targetFramework="net48" />
-  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.63.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.2" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="8.0.3" targetFramework="net48" />
+  <package id="Microsoft.Identity.Client" version="4.73.1" targetFramework="net48" />
+  <package id="Microsoft.Identity.Client.Extensions.Msal" version="4.73.1" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Abstractions" version="8.0.1" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="8.0.1" targetFramework="net48" />
   <package id="Microsoft.IdentityModel.Logging" version="8.0.1" targetFramework="net48" />
@@ -32,21 +34,21 @@
   <package id="Ninject.Web.Common.WebHost" version="3.3.2" targetFramework="net48" />
   <package id="Ninject.Web.WebApi" version="3.3.1" targetFramework="net48" />
   <package id="Ninject.Web.WebApi.WebHost" version="3.3.1" targetFramework="net48" />
-  <package id="Oracle.ManagedDataAccess.Core" version="2.19.230" targetFramework="net48" />
-  <package id="PcAxis.Core" version="1.2.5" targetFramework="net48" />
-  <package id="PCAxis.Menu" version="1.0.3" targetFramework="net48" />
-  <package id="PCAxis.Menu.ConfigDatamodelMenu" version="1.0.8" targetFramework="net48" />
-  <package id="PCAxis.Menu.MsSqlDatamodelMenu" version="1.0.4" targetFramework="net48" />
-  <package id="PCAxis.Menu.OracleDatamodelMenu" version="1.0.3" targetFramework="net48" />
-  <package id="PCAxis.Metadata" version="1.0.3" targetFramework="net48" />
-  <package id="PcAxis.Query" version="1.0.9" targetFramework="net48" />
-  <package id="PcAxis.Sql" version="1.2.4" targetFramework="net48" />
+  <package id="Oracle.ManagedDataAccess.Core" version="2.19.280" targetFramework="net48" />
+  <package id="PcAxis.Core" version="1.2.6" targetFramework="net48" />
+  <package id="PCAxis.Menu" version="1.0.4" targetFramework="net48" />
+  <package id="PCAxis.Menu.ConfigDatamodelMenu" version="1.0.9" targetFramework="net48" />
+  <package id="PCAxis.Menu.MsSqlDatamodelMenu" version="1.0.5" targetFramework="net48" />
+  <package id="PCAxis.Menu.OracleDatamodelMenu" version="1.0.4" targetFramework="net48" />
+  <package id="PCAxis.Metadata" version="1.0.4" targetFramework="net48" />
+  <package id="PcAxis.Query" version="1.0.10" targetFramework="net48" />
+  <package id="PcAxis.Sql" version="1.4.5" targetFramework="net48" />
   <package id="Px.Dcat" version="2.0.6" targetFramework="net48" />
-  <package id="PXWeb.SavedQuery.MsSql" version="1.0.4" targetFramework="net48" />
-  <package id="PXWeb.SavedQuery.Oracle" version="1.0.6" targetFramework="net48" />
+  <package id="PXWeb.SavedQuery.MsSql" version="1.0.5" targetFramework="net48" />
+  <package id="PXWeb.SavedQuery.Oracle" version="1.0.7" targetFramework="net48" />
   <package id="SixLabors.Fonts" version="1.0.0" targetFramework="net48" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.ClientModel" version="1.0.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.6.0" targetFramework="net48" />
+  <package id="System.ClientModel" version="1.6.0" targetFramework="net48" />
   <package id="System.Configuration.ConfigurationManager" version="8.0.1" targetFramework="net48" />
   <package id="System.Data.Common" version="4.3.0" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="8.0.1" targetFramework="net48" />
@@ -58,14 +60,14 @@
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net48" />
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net48" />
   <package id="System.IO.Packaging" version="8.0.1" targetFramework="net48" />
-  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
-  <package id="System.Memory.Data" version="8.0.0" targetFramework="net48" />
+  <package id="System.Memory" version="4.6.0" targetFramework="net48" />
+  <package id="System.Memory.Data" version="8.0.1" targetFramework="net48" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net48" />
   <package id="System.Reflection.Emit.ILGeneration" version="4.7.0" targetFramework="net48" />
   <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net48" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.AccessControl" version="6.0.1" targetFramework="net48" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net48" />
@@ -73,12 +75,12 @@
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.ProtectedData" version="8.0.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net48" />
-  <package id="System.Security.Cryptography.Xml" version="8.0.1" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Xml" version="8.0.2" targetFramework="net48" />
   <package id="System.Security.Permissions" version="8.0.0" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net48" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net48" />
   <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net48" />
-  <package id="System.Text.Json" version="8.0.5" targetFramework="net48" />
+  <package id="System.Text.Json" version="8.0.6" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
   <package id="Ude.NetStandard" version="1.2.0" targetFramework="net48" />

--- a/PxWeb.Test/PxWeb.Test.csproj
+++ b/PxWeb.Test/PxWeb.Test.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="3.0.3" />
+    <PackageReference Include="log4net" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />


### PR DESCRIPTION
- Updated various NuGet package references, including Azure.Core, Azure.Identity, and Microsoft.Data.SqlClient, to their latest versions for improved compatibility and security.
- Added `log4net` version 3.1.0 to enhance logging capabilities.
- Changed target framework from `net6.0` to `net8.0` in `PxWeb.Test.csproj` for better performance and features.
- Incremented versions for `PCAxis.Menu`, `PCAxis.Query`, and `PCAxis.Serializers` to include new functionalities.
- Updated references in `PXWeb.csproj` to ensure correct dependency versions are used.