### PR TITLE
Change to short-circuit operator AndAlso

### DIFF
--- a/PCAxis.Web.Controls/VariableSelector/VariableSelectorCodebehind.vb
+++ b/PCAxis.Web.Controls/VariableSelector/VariableSelectorCodebehind.vb
@@ -470,7 +470,7 @@ Public Class VariableSelectorCodebehind
             Dim contentDictionary As New Dictionary(Of String, String)()
 
             'Set PaxiomManager.Content if only one content is selected and RemoveSingleContent is true
-            If Settings.Metadata.RemoveSingleContent = True And PaxiomManager.PaxiomModel.Meta.ContentVariable IsNot Nothing And sels.FirstOrDefault(Function(x) x.VariableCode.Equals(PaxiomManager.PaxiomModel.Meta.ContentVariable.Code)).ValueCodes.Count = 1 Then
+            If Settings.Metadata.RemoveSingleContent = True And PaxiomManager.PaxiomModel.Meta.ContentVariable IsNot Nothing AndAlso sels.FirstOrDefault(Function(x) x.VariableCode.Equals(PaxiomManager.PaxiomModel.Meta.ContentVariable.Code)).ValueCodes.Count = 1 Then
                 contentDictionary.Add(sels.FirstOrDefault(Function(x) x.VariableCode.Equals(PaxiomManager.PaxiomModel.Meta.ContentVariable.Code)).VariableCode, sels.FirstOrDefault(Function(x) x.VariableCode.Equals(PaxiomManager.PaxiomModel.Meta.ContentVariable.Code)).ValueCodes(0))
             Else
                 contentDictionary = Nothing


### PR DESCRIPTION
Prevent evaluation of last expression to fix nullpointer exception for cases where left side evaluates to false (Meta.ContentVariable is nothing)